### PR TITLE
Address/Balance database functions

### DIFF
--- a/fat/fat2/pticker.go
+++ b/fat/fat2/pticker.go
@@ -116,5 +116,5 @@ func (t PTicker) String() string {
 	if t <= PTickerInvalid || PTickerMax <= t {
 		return fmt.Errorf("invalid token type").Error()
 	}
-	return validPTickerStrings[int(t)]
+	return validPTickerStrings[int(t) - 1]
 }

--- a/node/pegnet/addresses.go
+++ b/node/pegnet/addresses.go
@@ -102,6 +102,9 @@ func (p *Pegnet) SelectBalance(adr *factom.FAAddress, ticker fat2.PTicker) (uint
 	stmt := fmt.Sprintf(stmtStringFmt, strings.ToLower(ticker.String()))
 	err := p.DB.QueryRow(stmt, adr[:]).Scan(&balance)
 	if err != nil {
+		if err.Error() == "sql: no rows in result set" {
+			return 0, nil
+		}
 		return 0, err
 	}
 	return balance, nil
@@ -154,6 +157,9 @@ func (p *Pegnet) SelectBalances(adr *factom.FAAddress) (map[fat2.PTicker]uint64,
 		&balances[fat2.PTickerDCR],
 	)
 	if err != nil {
+		if err.Error() == "sql: no rows in result set" {
+			return balanceMap, nil
+		}
 		return nil, err
 	}
 	for i := fat2.PTickerInvalid + 1; i < fat2.PTickerMax; i++ {

--- a/node/pegnet/addresses_test.go
+++ b/node/pegnet/addresses_test.go
@@ -1,0 +1,150 @@
+package pegnet_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"os/user"
+	"testing"
+
+	"github.com/Factom-Asset-Tokens/factom"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/pegnet/pegnetd/fat/fat2"
+	. "github.com/pegnet/pegnetd/node/pegnet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupPegnet() (*Pegnet, error) {
+	// Taken from a combination of Pegnet.New() and Pegnet.Init()
+	// just avoiding the config for now
+	p := new(Pegnet)
+	usr, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+	path := fmt.Sprintf("%s/pegnet-tmp.db", usr.HomeDir)
+	_ = os.Remove(path)
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		return nil, err
+	}
+	p.DB = db
+	err = p.CreateTableAddresses()
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func tearDownPegnet(p *Pegnet) {
+	_ = p.DB.Close()
+	usr, _ := user.Current()
+	path := fmt.Sprintf("%s/pegnet-tmp.db", usr.HomeDir)
+	_ = os.Remove(path)
+}
+
+func TestPegnet_SelectBalance_Empty(t *testing.T) {
+	p, err := setupPegnet()
+	require.NoError(t, err)
+	defer tearDownPegnet(p)
+
+	var adr factom.FAAddress
+	balance, err := p.SelectBalance(&adr, fat2.PTickerPEG)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), balance)
+}
+
+func TestPegnet_SelectBalance_InvalidTicker(t *testing.T) {
+	p, err := setupPegnet()
+	require.NoError(t, err)
+	defer tearDownPegnet(p)
+
+	var adr factom.FAAddress
+	_, err = p.SelectBalance(&adr, fat2.PTicker(-1))
+	assert.EqualError(t, err, "invalid token type")
+	_, err = p.SelectBalance(&adr, fat2.PTickerInvalid)
+	assert.EqualError(t, err, "invalid token type")
+	_, err = p.SelectBalance(&adr, fat2.PTickerMax)
+	assert.EqualError(t, err, "invalid token type")
+	_, err = p.SelectBalance(&adr, fat2.PTicker(1000000000))
+	assert.EqualError(t, err, "invalid token type")
+}
+
+func TestPegnet_SelectBalances_Empty(t *testing.T) {
+	p, err := setupPegnet()
+	require.NoError(t, err)
+	defer tearDownPegnet(p)
+
+	var adr factom.FAAddress
+	balances, err := p.SelectBalances(&adr)
+	require.NoError(t, err)
+	require.Equal(t, int(fat2.PTickerMax)-1, len(balances), "Unexpected number of balances returned")
+	for i := fat2.PTickerInvalid + 1; i < fat2.PTickerMax; i++ {
+		assert.Equal(t, uint64(0), balances[i])
+	}
+}
+
+func TestPegnet_AddToBalance(t *testing.T) {
+	p, err := setupPegnet()
+	require.NoError(t, err)
+	defer tearDownPegnet(p)
+
+	tx, err := p.DB.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+
+	var adr factom.FAAddress
+	_, err = p.AddToBalance(tx, &adr, fat2.PTickerPEG, 100)
+	require.NoError(t, err)
+
+	balance, err := p.SelectPendingBalance(tx, &adr, fat2.PTickerPEG)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), balance, "Incorrect pending balance before tx.Commit()")
+
+	balance, err = p.SelectBalance(&adr, fat2.PTickerPEG)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), balance, "Incorrect finalized balance before tx.Commit()")
+
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	balance, err = p.SelectBalance(&adr, fat2.PTickerPEG)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), balance, "Incorrect finalized balance after tx.Commit()")
+}
+
+func TestPegnet_SubFromBalance(t *testing.T) {
+	p, err := setupPegnet()
+	require.NoError(t, err)
+	defer tearDownPegnet(p)
+
+	tx, err := p.DB.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+
+	var adr factom.FAAddress
+	_, txErr, err := p.SubFromBalance(tx, &adr, fat2.PTickerPEG, 100)
+	require.NoError(t, err)
+	assert.EqualError(t, txErr, "insufficient balance: FA1y5ZGuHSLmf2TqNf6hVMkPiNGyQpQDTFJvDLRkKQaoPo4bmbgu")
+
+	_, err = p.AddToBalance(tx, &adr, fat2.PTickerPEG, 100)
+	require.NoError(t, err)
+	_, txErr, err = p.SubFromBalance(tx, &adr, fat2.PTickerPEG, 50)
+	require.NoError(t, err)
+	require.NoError(t, txErr)
+
+	balance, err := p.SelectPendingBalance(tx, &adr, fat2.PTickerPEG)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(50), balance, "Incorrect pending balance before tx.Commit()")
+
+	balance, err = p.SelectBalance(&adr, fat2.PTickerPEG)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), balance, "Incorrect finalized balance before tx.Commit()")
+
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	balance, err = p.SelectBalance(&adr, fat2.PTickerPEG)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(50), balance, "Incorrect finalized balance after tx.Commit()")
+}

--- a/node/pegnet/addresses_test.go
+++ b/node/pegnet/addresses_test.go
@@ -3,9 +3,7 @@ package pegnet_test
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"os"
-	"os/user"
 	"testing"
 
 	"github.com/Factom-Asset-Tokens/factom"
@@ -20,11 +18,7 @@ func setupPegnet() (*Pegnet, error) {
 	// Taken from a combination of Pegnet.New() and Pegnet.Init()
 	// just avoiding the config for now
 	p := new(Pegnet)
-	usr, err := user.Current()
-	if err != nil {
-		return nil, err
-	}
-	path := fmt.Sprintf("%s/pegnet-tmp.db", usr.HomeDir)
+	path := "/tmp/pegnet-tmp.db"
 	_ = os.Remove(path)
 	db, err := sql.Open("sqlite3", path)
 	if err != nil {
@@ -40,9 +34,7 @@ func setupPegnet() (*Pegnet, error) {
 
 func tearDownPegnet(p *Pegnet) {
 	_ = p.DB.Close()
-	usr, _ := user.Current()
-	path := fmt.Sprintf("%s/pegnet-tmp.db", usr.HomeDir)
-	_ = os.Remove(path)
+	_ = os.Remove("/tmp/pegnet-tmp.db")
 }
 
 func TestPegnet_SelectBalance_Empty(t *testing.T) {


### PR DESCRIPTION
Modifies the `pn_addresses` table schema to allow for default values and implement wrappers for the following common queries:
- `AddToBalance(tx *sql.Tx, adr *factom.FAAddress, ticker fat2.PTicker, value uint64)` - sub-block granularity
- `SubFromBalance(tx *sql.Tx, adr *factom.FAAddress, ticker fat2.PTicker, value uint64)` - sub-block granularity
- `SelectPendingBalance(tx *sql.Tx, adr *factom.FAAddress, ticker fat2.PTicker)`  - sub-block granularity
- `SelectBalance(adr *factom.FAAddress, ticker fat2.PTicker)` - whole block granularity
- `SelectBalances(adr *factom.FAAddress)` - whole block granularity

The usage pattern we have decided on is to simply pass around a single `sql.Tx` as the current "pending block" that we will be applying balance deltas to as they are parsed. That will be implemented separately, these are just functions to facilitate that flow.