### PR TITLE
fix paths on windows

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,7 +77,7 @@ func always(cmd *cobra.Command, args []string) {
 
 	// Also init some defaults
 	viper.SetDefault(config.DBlockSyncRetryPeriod, time.Second*5)
-	viper.SetDefault(config.SqliteDBPath, "$HOME/pegnetd/mainnet/sql.db")
+	viper.SetDefault(config.SqliteDBPath, "$HOME/.pegnetd/mainnet/sql.db")
 
 	// Catch ctl+c
 	signalChan := make(chan os.Signal, 1)

--- a/node/pegnet/pegnet.go
+++ b/node/pegnet/pegnet.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/pegnet/pegnet/modules/grader"
 	"github.com/pegnet/pegnetd/config"
@@ -32,8 +34,11 @@ func New(conf *viper.Viper) *Pegnet {
 
 func (p *Pegnet) Init() error {
 	// The path should contain a $HOME env variable.
-	// TODO: Check that works on windows....
-	path := os.ExpandEnv(viper.GetString(config.SqliteDBPath))
+	rawpath := viper.GetString(config.SqliteDBPath)
+	if runtime.GOOS == "windows" {
+		rawpath = strings.Replace(rawpath, "$HOME", "$USERPROFILE", -1)
+	}
+	path := os.ExpandEnv(rawpath)
 
 	// Ensure the path exists
 	dir := filepath.Dir(path)
@@ -43,7 +48,6 @@ func (p *Pegnet) Init() error {
 	}
 
 	log.Infof("Opening database from '%s'", path)
-	// TODO: Idc which sqlite to use. Change this if you want.T
 	db, err := sql.Open("sqlite3", path)
 	if err != nil {
 		return err


### PR DESCRIPTION
https://github.com/pegnet/pegnetd/blob/2c9be2dfa3d89981f40aaeffd909823611a87239/node/pegnet/pegnet.go#L35

This did not work on windows, so I'm just renaming $HOME to $USERPATH which does work. I also fixed the 'default' path to include the . that disappeared, bringing it back to consistency with the .toml config setting