### PR TITLE
Add optional arbitrary sqlite modes

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,9 @@ func init() {
 	rootCmd.PersistentFlags().StringP("pegnetd", "p", "http://localhost:8070", "The url to the pegnetd endpoint without a trailing slash")
 	rootCmd.PersistentFlags().String("api", "8070", "Change the api listening port for the api")
 
+	rootCmd.Flags().String("dbmode", "", "Turn on custom sqlite modes")
+	rootCmd.Flags().Bool("wal", false, "Turn on WAL mode for sqlite")
+
 	// This is for testing purposes
 	rootCmd.PersistentFlags().Bool("testing", false, "If this flag is set, all v2 activations heights are set to 0.")
 }
@@ -92,6 +95,8 @@ func always(cmd *cobra.Command, args []string) {
 	_ = viper.BindPFlag(config.Wallet, cmd.Flags().Lookup("wallet"))
 	_ = viper.BindPFlag(config.Pegnetd, cmd.Flags().Lookup("pegnetd"))
 	_ = viper.BindPFlag(config.APIListen, cmd.Flags().Lookup("api"))
+	_ = viper.BindPFlag(config.SQLDBWalMode, cmd.Flags().Lookup("wal"))
+	_ = viper.BindPFlag(config.CustomSQLDBMode, cmd.Flags().Lookup("dbmode"))
 
 	// Also init some defaults
 	viper.SetDefault(config.DBlockSyncRetryPeriod, time.Second*5)

--- a/config/locations.go
+++ b/config/locations.go
@@ -9,6 +9,9 @@ const (
 	// DBlockSync Stuff
 	DBlockSyncRetryPeriod = "dblocksync.retry"
 
+	CustomSQLDBMode = "db.mode"
+	SQLDBWalMode    = "db.wal"
+
 	Server  = "app.Server"
 	Wallet  = "app.Wallet"
 	Pegnetd = "app.Pegnetd"

--- a/node/pegnet/pegnet.go
+++ b/node/pegnet/pegnet.go
@@ -47,8 +47,18 @@ func (p *Pegnet) Init() error {
 		return err
 	}
 
+	openmode := path
+	modes := ""
+	if p.Config.GetBool(config.SQLDBWalMode) {
+		modes += "_journal=WAL&"
+	}
+	modes += p.Config.GetString(config.CustomSQLDBMode)
+	if modes != "" {
+		openmode += "?" + modes
+	}
+
 	log.Infof("Opening database from '%s'", path)
-	db, err := sql.Open("sqlite3", path)
+	db, err := sql.Open("sqlite3", openmode)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Added a flag for WAL mode, and ability to use arbitrary modes.
There might be better modes to use that can be discovered and
deployed with a config file vs a code update

Inspired by Adam's comment:
>Use write ahead log mode and you'll have even lower chance of corruption issues. Then nothing gets into the dB file until its committed. And sqlite can recover from a crash when the Wal didn't get written back to the db during close.