### PR TITLE
Add PEG rate pricing after an activation height

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,6 +84,7 @@ func always(cmd *cobra.Command, args []string) {
 		node.PegnetActivation = uint32(act)
 		node.GradingV2Activation = uint32(act)
 		node.TransactionConversionActivation = uint32(act)
+		node.PEGPricingActivation = uint32(act)
 		common.ActivationHeights[common.MainNetwork] = int64(act)
 		common.ActivationHeights[common.TestNetwork] = int64(act)
 		common.GradingHeights[common.MainNetwork] = func(height int64) uint8 { return 2 }

--- a/node/node.go
+++ b/node/node.go
@@ -22,8 +22,8 @@ var GradingV2Activation uint32 = 210330
 // Target Activation Height is Oct 7, 2019 15 UTC
 var TransactionConversionActivation uint32 = 213237
 
-// TODO: determine when we want PEG pricing to go live
-var PEGPricingActivation uint32 = 214000
+// Estimated to be Oct 14 2019, 15:00:00 UTC
+var PEGPricingActivation uint32 = 214287
 
 type Pegnetd struct {
 	FactomClient *factom.Client

--- a/node/node.go
+++ b/node/node.go
@@ -22,6 +22,9 @@ var GradingV2Activation uint32 = 210330
 // Target Activation Height is Oct 7, 2019 15 UTC
 var TransactionConversionActivation uint32 = 213237
 
+// TODO: determine when we want PEG pricing to go live
+var PEGPricingActivation uint32 = 214000
+
 type Pegnetd struct {
 	FactomClient *factom.Client
 	Config       *viper.Viper

--- a/node/pegnet/addresses.go
+++ b/node/pegnet/addresses.go
@@ -266,11 +266,10 @@ func (p *Pegnet) SelectIssuances() (map[fat2.PTicker]uint64, error) {
 	var sb strings.Builder
 	for i := fat2.PTickerInvalid + 1; i < fat2.PTickerMax-1; i++ {
 		tickerLower := strings.ToLower(i.String())
-		sb.WriteString(fmt.Sprintf("SUM(%s_balance), ", tickerLower))
+		sb.WriteString(fmt.Sprintf("IFNULL(SUM(%s_balance), 0), ", tickerLower))
 	}
 	tickerLower := strings.ToLower((fat2.PTickerMax - 1).String())
-	sb.WriteString(fmt.Sprintf("SUM(%s_balance) ", tickerLower))
-
+	sb.WriteString(fmt.Sprintf("IFNULL(SUM(%s_balance), 0) ", tickerLower))
 	err := p.DB.QueryRow(fmt.Sprintf(queryFmt, sb.String())).Scan(
 		&issuances[fat2.PTickerPEG],
 		&issuances[fat2.PTickerUSD],

--- a/node/pegnet/grading.go
+++ b/node/pegnet/grading.go
@@ -61,12 +61,13 @@ func (p *Pegnet) insertRate(tx *sql.Tx, height uint32, ticker fat2.PTicker, rate
 
 // InsertRates adds all asset rates as rows, computing the rate for PEG if necessary
 func (p *Pegnet) InsertRates(tx *sql.Tx, height uint32, rates []opr.AssetUint, pricePEG bool) error {
-	for _, r := range rates {
-		if r.Name == "PEG" {
+	for i := range rates {
+		if rates[i].Name == "PEG" {
 			continue
 		}
-		r.Name = "p" + r.Name
-		err := p.insertRate(tx, height, fat2.StringToTicker(r.Name), r.Value)
+		// Correct rates to use `pAsset`
+		rates[i].Name = "p" + rates[i].Name
+		err := p.insertRate(tx, height, fat2.StringToTicker(rates[i].Name), rates[i].Value)
 		if err != nil {
 			return err
 		}
@@ -83,6 +84,7 @@ func (p *Pegnet) InsertRates(tx *sql.Tx, height uint32, rates []opr.AssetUint, p
 			if r.Name == "PEG" {
 				continue
 			}
+
 			assetCapitalization := new(big.Int).Mul(new(big.Int).SetUint64(issuance[fat2.StringToTicker(r.Name)]), new(big.Int).SetUint64(r.Value))
 			totalCapitalization.Add(totalCapitalization, assetCapitalization)
 		}

--- a/node/pegnet/pegnet.go
+++ b/node/pegnet/pegnet.go
@@ -35,7 +35,7 @@ func (p *Pegnet) Init() error {
 	// TODO: Come up with actual migrations.
 	// 		until then, we can just bump this version number
 	//		and make the database reset when we need to.
-	path += ".v2"
+	path += ".v3"
 
 	// Ensure the path exists
 	dir := filepath.Dir(path)

--- a/node/sync.go
+++ b/node/sync.go
@@ -168,7 +168,8 @@ func (d *Pegnetd) SyncBlock(ctx context.Context, tx *sql.Tx, height uint32) erro
 		}
 		winners := gradedBlock.Winners()
 		if 0 < len(winners) {
-			err = d.Pegnet.InsertRate(tx, height, winners[0].OPR.GetOrderedAssetsUint())
+			shouldPricePEG := PEGPricingActivation <= height
+			err = d.Pegnet.InsertRates(tx, height, winners[0].OPR.GetOrderedAssetsUint(), shouldPricePEG)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Add an activation height (TBD) for PEG conversions to go live, and also calculate the price of PEG when that height is reached or passed.

As a result of this discussion: https://github.com/pegnet/pegnet/pull/331#issuecomment-540130937 I have implemented pricing into pegnetd rather than the miner.

Where `PEG rate = (sum of all other asset capitalizations this block) / (sum of supply of all other assets last block)`. If this is off-base or I should be using bigints or something else, please correct me. This was just a first pass to get the code up here. Needs more testing and review.