### PR TITLE
Fix Pegnet.InsertRates invalid/old PTicker bug

### DIFF
--- a/node/pegnet/grading.go
+++ b/node/pegnet/grading.go
@@ -51,8 +51,8 @@ const createTableRate = `CREATE TABLE IF NOT EXISTS "pn_rate" (
 );
 `
 
-func (p *Pegnet) insertRate(tx *sql.Tx, height uint32, ticker fat2.PTicker, rate uint64) error {
-	_, err := tx.Exec("INSERT INTO pn_rate (height, token, value) VALUES ($1, $2, $3)", height, ticker.String(), rate)
+func (p *Pegnet) insertRate(tx *sql.Tx, height uint32, tickerString string, rate uint64) error {
+	_, err := tx.Exec("INSERT INTO pn_rate (height, token, value) VALUES ($1, $2, $3)", height, tickerString, rate)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func (p *Pegnet) InsertRates(tx *sql.Tx, height uint32, rates []opr.AssetUint, p
 		}
 		// Correct rates to use `pAsset`
 		rates[i].Name = "p" + rates[i].Name
-		err := p.insertRate(tx, height, fat2.StringToTicker(rates[i].Name), rates[i].Value)
+		err := p.insertRate(tx, height, rates[i].Name, rates[i].Value)
 		if err != nil {
 			return err
 		}
@@ -94,7 +94,7 @@ func (p *Pegnet) InsertRates(tx *sql.Tx, height uint32, rates []opr.AssetUint, p
 			ratePEG.Div(totalCapitalization, new(big.Int).SetUint64(issuance[fat2.PTickerPEG]))
 		}
 	}
-	err := p.insertRate(tx, height, fat2.PTickerPEG, ratePEG.Uint64())
+	err := p.insertRate(tx, height, fat2.PTickerPEG.String(), ratePEG.Uint64())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There is a bug that was encountered syncing against mainnet, where the old PTickers that we dropped are not in the fat2 package (and really shouldn't be since theyll never be used for transactions).

But this meant that they were inserted as PTickerInvalid in the database, and with multiple assets that were dropped, this broke the unique constraint on the pn_rates table.

Switched back to using a ticker string in the InsertRates function to accommodate until we come up with a more elegant solution to managing old/new asset tickers and when they are valid