### PR TITLE
Remove old assets from the SelectRates function

### DIFF
--- a/node/pegnet/grading.go
+++ b/node/pegnet/grading.go
@@ -204,7 +204,9 @@ func _extractAssets(rows *sql.Rows) (map[fat2.PTicker]uint64, error) {
 		if err := rows.Scan(&tickerName, &rateValue); err != nil {
 			return nil, err
 		}
-		assets[fat2.StringToTicker(tickerName)] = rateValue
+		if ticker := fat2.StringToTicker(tickerName); ticker != fat2.PTickerInvalid {
+			assets[ticker] = rateValue
+		}
 	}
 	return assets, nil
 }


### PR DESCRIPTION
The v1 asset prices are not useful for any application data as no transactions or conversions need to access their values. This PR removes them from the SelectRates results