### PR TITLE
TX History API

### DIFF
--- a/node/pegnet/pegnet.go
+++ b/node/pegnet/pegnet.go
@@ -76,9 +76,9 @@ func (p *Pegnet) createTables() error {
 		createTableWinners,
 		createTableTransactions,
 		createTableTransactionBatchHolding,
-		createTableTxHistory,
-		createTableTxHistoryAction,
-		createTableTxHistoryActionData,
+		createTableTxHistoryBatch,
+		createTableTxHistoryTx,
+		createTableTxHistoryLookup,
 	} {
 		if _, err := p.DB.Exec(sql); err != nil {
 			return err

--- a/node/pegnet/pegnet.go
+++ b/node/pegnet/pegnet.go
@@ -35,7 +35,7 @@ func (p *Pegnet) Init() error {
 	// TODO: Come up with actual migrations.
 	// 		until then, we can just bump this version number
 	//		and make the database reset when we need to.
-	path += ".v3"
+	path += ".v4"
 
 	// Ensure the path exists
 	dir := filepath.Dir(path)
@@ -76,6 +76,9 @@ func (p *Pegnet) createTables() error {
 		createTableWinners,
 		createTableTransactions,
 		createTableTransactionBatchHolding,
+		createTableTxHistory,
+		createTableTxHistoryAction,
+		createTableTxHistoryActionData,
 	} {
 		if _, err := p.DB.Exec(sql); err != nil {
 			return err

--- a/node/pegnet/txhistory.go
+++ b/node/pegnet/txhistory.go
@@ -2,60 +2,71 @@ package pegnet
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/Factom-Asset-Tokens/factom"
+	"github.com/pegnet/pegnet/modules/grader"
 	"github.com/pegnet/pegnetd/fat/fat2"
 )
 
 type HistoryAction int32
 
 const (
-	Transfer HistoryAction = iota
+	Invalid HistoryAction = iota
+	Transfer
 	Conversion
-	Burn
+	Coinbase
+	FCTBurn
 )
-const createTableTxHistory = `CREATE TABLE IF NOT EXISTS "pn_transaction_history" (
+const createTableTxHistoryBatch = `CREATE TABLE IF NOT EXISTS "pn_history_txbatch" (
+	"history_id"	INTEGER PRIMARY KEY,
 	"entry_hash"    BLOB NOT NULL,
 	"height"        INTEGER NOT NULL, -- height the tx is in
 	"blockorder"	INTEGER NOT NULL,
 	"timestamp"		INTEGER NOT NULL,
 	"executed"		INTEGER NOT NULL, -- -1 if failed, 0 if pending, height it was applied at otherwise
 
-	PRIMARY KEY("entry_hash", "height"),
+	UNIQUE("entry_hash", "height"),
 	FOREIGN KEY("height") REFERENCES "pn_grade"
 );
-CREATE INDEX IF NOT EXISTS "idx_transaction_history_entry_hash" ON "pn_transaction_history"("entry_hash");
-CREATE INDEX IF NOT EXISTS "idx_transaction_history_timestamp" ON "pn_transaction_history"("timestamp");
+CREATE INDEX IF NOT EXISTS "idx_history_txbatch_entry_hash" ON "pn_history_txbatch"("entry_hash");
+CREATE INDEX IF NOT EXISTS "idx_history_txbatch_timestamp" ON "pn_history_txbatch"("timestamp");
+CREATE INDEX IF NOT EXISTS "idx_history_txbatch_height" ON "pn_history_txbatch"("height");
 `
 
-const createTableTxHistoryAction = `CREATE TABLE IF NOT EXISTS "pn_transaction_history_action" (
+const createTableTxHistoryTx = `CREATE TABLE IF NOT EXISTS "pn_history_transaction" (
 	"entry_hash"	BLOB NOT NULL,
 	"tx_index"		INTEGER NOT NULL,	-- the batch index
 	"action_type"	INTEGER NOT NULL,
-	"address"       BLOB NOT NULL,
-	"asset"			STRING NOT NULL,
-	"amount"		INTEGER NOT NULL,
+	"from_address"  BLOB NOT NULL,
+	"from_asset"	STRING NOT NULL,
+	"from_amount"	INTEGER NOT NULL,
+	"to_asset"		STRING NOT NULL,	-- used for NOT transfers
+	"to_amount"		INTEGER NOT NULL,	-- used for NOT transfers
+	"outputs"		BLOB NOT NULL,		-- used for transfers only
 
 	PRIMARY KEY("entry_hash", "tx_index"),
-	FOREIGN KEY("entry_hash") REFERENCES "pn_transaction_history"
+	FOREIGN KEY("entry_hash") REFERENCES "pn_history_txbatch"
 );
-CREATE INDEX IF NOT EXISTS "idx_transaction_history_address" ON "pn_transaction_history"("address");`
+CREATE INDEX IF NOT EXISTS "idx_history_transaction_entry_hash" ON "pn_history_transaction"("entry_hash");
+`
 
-const createTableTxHistoryActionData = `CREATE TABLE IF NOT EXISTS "pn_transaction_history_action_data" (
-	"entry_hash"		BLOB NOT NULL,
-	"tx_index"			INTEGER NOT NULL,	-- the batch index
-	"tx_index_index" 	INTEGER NOT NULL,
-	"to_address"		BLOB NOT NULL,		-- transfer recipient
-	"to_asset"			STRING NOT NULL,	-- conversion/burn
-	"to_amount"			INTEGER NOT NULL,
-	
-	PRIMARY KEY("entry_hash", "tx_index", "tx_index_index"),
-	FOREIGN KEY("entry_hash") REFERENCES "pn_transaction_history"
-);`
+const createTableTxHistoryLookup = `CREATE TABLE IF NOT EXISTS "pn_history_lookup" (
+	"entry_hash"	INTEGER NOT NULL,
+	"tx_index"		INTEGER NOT NULL,
+	"address"		BLOB NOT NULL,
 
-type TxAction struct {
+	PRIMARY KEY("entry_hash", "tx_index", "address"),
+	FOREIGN KEY("entry_hash", "tx_index") REFERENCES "pn_history_transaction"
+);
+CREATE INDEX IF NOT EXISTS "idx_history_lookup_address" ON "pn_history_lookup"("address");
+CREATE INDEX IF NOT EXISTS "idx_history_lookup_entry_index" ON "pn_history_lookup"("entry_hash", "tx_index");`
+
+const insertLookupQuery = `INSERT INTO pn_history_lookup (entry_hash, tx_index, address) VALUES (?, ?, ?) ON CONFLICT DO NOTHING;`
+
+type HistoryTransaction struct {
 	Hash      *factom.Bytes32 `json:"hash"`
 	Height    int64           `json:"height"`
 	Timestamp time.Time       `json:"timestamp"`
@@ -63,56 +74,65 @@ type TxAction struct {
 	TxIndex   int             `json:"txindex"`
 	TxAction  HistoryAction   `json:"txaction"`
 
-	ActionIndex int               `json:"actionindex"`
-	FromAddress *factom.FAAddress `json:"fromaddress"`
-	FromAsset   string            `json:"fromasset"`
-	FromAmount  int64             `json:"fromamount"`
-	ToAddress   *factom.FAAddress `json:"toaddress"`
-	ToAsset     string            `json:"toasset"`
-	ToAmount    int64             `json:"toamount"`
+	FromAddress *factom.FAAddress          `json:"fromaddress"`
+	FromAsset   string                     `json:"fromasset"`
+	FromAmount  int64                      `json:"fromamount"`
+	ToAsset     string                     `json:"toasset,omitempty"`
+	ToAmount    int64                      `json:"toamount,omitempty"`
+	Outputs     []HistoryTransactionOutput `json:"outputs,omitempty"`
+}
+type HistoryTransactionOutput struct {
+	Address *factom.FAAddress `json:"address"`
+	Amount  int64             `json:"amount"`
 }
 
-func _turnRowsIntoTxActions(rows *sql.Rows) ([]TxAction, error) {
-	var actions []TxAction
+func _turnRowsIntoHistoryTransactions(rows *sql.Rows) ([]HistoryTransaction, error) {
+	var actions []HistoryTransaction
 	for rows.Next() {
-		var a TxAction
-		var ts int64
-		var hash, from, to []byte
+		var tx HistoryTransaction
+		var ts, id int64
+		var hash, from, outputs []byte
 		err := rows.Scan(
-			&hash, &a.Height, &ts, &a.Executed, // history
-			&a.TxIndex, &a.TxAction, &from, &a.FromAsset, &a.FromAmount, // action
-			&a.ActionIndex, &to, &a.ToAsset, &a.ToAmount) // data
+			&id, &hash, &tx.Height, &ts, &tx.Executed, // history
+			&tx.TxIndex, &tx.TxAction, &from, &tx.FromAsset, &tx.FromAmount, // action
+			&outputs, &tx.ToAsset, &tx.ToAmount) // data
 		if err != nil {
 			return nil, err
 		}
-		a.Hash = factom.NewBytes32(hash)
-		a.Timestamp = time.Unix(ts, 0)
-		var addr1, addr2 factom.FAAddress
-		addr1 = factom.FAAddress(*factom.NewBytes32(from))
-		a.FromAddress = &addr1
-		addr2 = factom.FAAddress(*factom.NewBytes32(to))
-		a.ToAddress = &addr2
-		actions = append(actions, a)
+		tx.Hash = factom.NewBytes32(hash)
+		tx.Timestamp = time.Unix(ts, 0)
+		var addr factom.FAAddress
+		addr = factom.FAAddress(*factom.NewBytes32(from))
+		tx.FromAddress = &addr
+
+		if tx.TxAction == Transfer {
+			var output []HistoryTransactionOutput
+			if err = json.Unmarshal(outputs, &output); err != nil { // should never fail unless database data is corrupt
+				return nil, fmt.Errorf("database corruption %d %v", id, err)
+			}
+			tx.Outputs = output
+		}
+
+		actions = append(actions, tx)
 	}
 	return actions, nil
 }
 
-const baseTxCountQuery = `SELECT COUNT(*) FROM pn_transaction_history history, pn_transaction_history_action action, pn_transaction_history_action_data data
-WHERE history.entry_hash = action.entry_hash AND action.entry_hash = data.entry_hash AND action.tx_index = data.tx_index AND (%s)`
+const baseTxCountQuery = `SELECT COUNT(*) FROM pn_history_txbatch batch, pn_history_transaction tx
+WHERE batch.entry_hash = tx.entry_hash AND (%s)`
 
 const baseTxActionQuery = `SELECT 
-	history.entry_hash, history.height, history.timestamp, history.executed,
-	action.tx_index, action.action_type, action.address, action.asset, action.amount,
-	data.tx_index_index, data.to_address, data.to_asset, data.to_amount
-FROM pn_transaction_history history, pn_transaction_history_action action, pn_transaction_history_action_data data
-WHERE history.entry_hash = action.entry_hash AND action.entry_hash = data.entry_hash AND action.tx_index = data.tx_index
-	AND (%s)
-ORDER BY %s
+	batch.history_id, batch.entry_hash, batch.height, batch.timestamp, batch.executed,
+	tx.tx_index, tx.action_type, tx.from_address, tx.from_asset, tx.from_amount, tx.outputs,
+	tx.to_asset, tx.to_amount
+FROM pn_history_txbatch batch, pn_history_transaction tx
+WHERE batch.entry_hash = tx.entry_hash AND (%s)
+ORDER BY batch.history_id %s
 LIMIT 50 OFFSET %d`
 
-func (p *Pegnet) SelectTransactionHistoryActionsByHash(hash *factom.Bytes32, offset int, descending bool) ([]TxAction, int, error) {
+func (p *Pegnet) SelectTransactionHistoryActionsByHash(hash *factom.Bytes32, offset int, descending bool) ([]HistoryTransaction, int, error) {
 	var count int
-	err := p.DB.QueryRow(fmt.Sprintf(baseTxCountQuery, "history.entry_hash = ?"), hash[:]).Scan(&count)
+	err := p.DB.QueryRow(fmt.Sprintf(baseTxCountQuery, "batch.entry_hash = ?"), hash[:]).Scan(&count)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -125,12 +145,12 @@ func (p *Pegnet) SelectTransactionHistoryActionsByHash(hash *factom.Bytes32, off
 		return nil, 0, fmt.Errorf("offset too big")
 	}
 
-	order := "history.height, history.blockorder"
+	order := "ASC"
 	if descending {
-		order = "history.height DESC, history.blockorder DESC"
+		order = "DESC"
 	}
 
-	q := fmt.Sprintf(baseTxActionQuery, "history.entry_hash = ?", order, offset)
+	q := fmt.Sprintf(baseTxActionQuery, "batch.entry_hash = ?", order, offset)
 
 	rows, err := p.DB.Query(q, hash[:])
 	if err != nil {
@@ -138,45 +158,52 @@ func (p *Pegnet) SelectTransactionHistoryActionsByHash(hash *factom.Bytes32, off
 	}
 	defer rows.Close()
 
-	a, e := _turnRowsIntoTxActions(rows)
+	a, e := _turnRowsIntoHistoryTransactions(rows)
 	return a, count, e
 }
 
-func (p *Pegnet) SelectTransactionHistoryActionsByAddress(addr *factom.FAAddress, offset int, descending bool) ([]TxAction, int, error) {
+const addressQuery = `SELECT 
+	batch.history_id, batch.entry_hash, batch.height, batch.timestamp, batch.executed,
+	tx.tx_index, tx.action_type, tx.from_address, tx.from_asset, tx.from_amount, tx.outputs,
+	tx.to_asset, tx.to_amount
+FROM pn_history_lookup lookup, pn_history_txbatch batch, pn_history_transaction tx
+WHERE lookup.address = ? AND lookup.entry_hash = tx.entry_hash AND lookup.tx_index = tx.tx_index AND batch.entry_hash = tx.entry_hash
+ORDER BY batch.history_id %s
+LIMIT 50 OFFSET %d`
+const addressQueryCount = `SELECT COUNT(*) FROM pn_history_lookup lookup WHERE lookup.address = ?`
+
+func (p *Pegnet) SelectTransactionHistoryActionsByAddress(addr *factom.FAAddress, offset int, descending bool) ([]HistoryTransaction, int, error) {
 	var count int
-	err := p.DB.QueryRow(fmt.Sprintf(baseTxCountQuery, "action.address = ? OR data.to_address = ?"), addr[:], addr[:]).Scan(&count)
+	err := p.DB.QueryRow(addressQueryCount, addr[:]).Scan(&count)
 	if err != nil {
 		return nil, 0, err
 	}
-
 	if count == 0 {
 		return nil, 0, nil
 	}
-
 	if offset > count {
 		return nil, 0, fmt.Errorf("offset too big")
 	}
 
-	order := "history.height, history.blockorder"
+	order := "ASC"
 	if descending {
-		order = "history.height DESC, history.blockorder DESC"
+		order = "DESC"
 	}
+	q := fmt.Sprintf(addressQuery, order, offset)
 
-	q := fmt.Sprintf(baseTxActionQuery, "action.address = ? OR data.to_address = ?", order, offset)
-
-	rows, err := p.DB.Query(q, addr[:], addr[:])
+	rows, err := p.DB.Query(q, addr[:])
 	if err != nil {
 		return nil, 0, err
 	}
 	defer rows.Close()
 
-	a, e := _turnRowsIntoTxActions(rows)
+	a, e := _turnRowsIntoHistoryTransactions(rows)
 	return a, count, e
 }
 
-func (p *Pegnet) SelectTransactionHistoryActionsByHeight(height uint32, offset int, descending bool) ([]TxAction, int, error) {
+func (p *Pegnet) SelectTransactionHistoryActionsByHeight(height uint32, offset int, descending bool) ([]HistoryTransaction, int, error) {
 	var count int
-	err := p.DB.QueryRow(fmt.Sprintf(baseTxCountQuery, "history.height = ?"), height).Scan(&count)
+	err := p.DB.QueryRow(fmt.Sprintf(baseTxCountQuery, "batch.height = ?"), height).Scan(&count)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -189,12 +216,12 @@ func (p *Pegnet) SelectTransactionHistoryActionsByHeight(height uint32, offset i
 		return nil, 0, fmt.Errorf("offset too big")
 	}
 
-	order := "history.height, history.blockorder"
+	order := "ASC"
 	if descending {
-		order = "history.height DESC, history.blockorder DESC"
+		order = "DESC"
 	}
 
-	q := fmt.Sprintf(baseTxActionQuery, "history.height = ?", order, offset)
+	q := fmt.Sprintf(baseTxActionQuery, "batch.height = ?", order, offset)
 
 	rows, err := p.DB.Query(q, height)
 	if err != nil {
@@ -202,13 +229,13 @@ func (p *Pegnet) SelectTransactionHistoryActionsByHeight(height uint32, offset i
 	}
 	defer rows.Close()
 
-	a, e := _turnRowsIntoTxActions(rows)
+	a, e := _turnRowsIntoHistoryTransactions(rows)
 	return a, count, e
 }
 
 func (p *Pegnet) SelectTransactionHistoryStatus(hash *factom.Bytes32) (uint32, uint32, error) {
 	var height, executed uint32
-	err := p.DB.QueryRow("SELECT height, executed FROM pn_transaction_history WHERE entry_hash = ?", hash[:]).Scan(&height, &executed)
+	err := p.DB.QueryRow("SELECT height, executed FROM pn_history_txbatch WHERE entry_hash = ?", hash[:]).Scan(&height, &executed)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return 0, 0, nil
@@ -219,7 +246,7 @@ func (p *Pegnet) SelectTransactionHistoryStatus(hash *factom.Bytes32) (uint32, u
 }
 
 func (p *Pegnet) SetTransactionHistoryExecuted(tx *sql.Tx, txbatch *fat2.TransactionBatch, executed int64) error {
-	stmt, err := tx.Prepare(`UPDATE "pn_transaction_history" SET executed = ? WHERE entry_hash = ?`)
+	stmt, err := tx.Prepare(`UPDATE "pn_history_txbatch" SET executed = ? WHERE entry_hash = ?`)
 	if err != nil {
 		return err
 	}
@@ -231,7 +258,7 @@ func (p *Pegnet) SetTransactionHistoryExecuted(tx *sql.Tx, txbatch *fat2.Transac
 }
 
 func (p *Pegnet) SetTransactionHistoryConvertedAmount(tx *sql.Tx, txbatch *fat2.TransactionBatch, index int, amount int64) error {
-	stmt, err := tx.Prepare(`UPDATE "pn_transaction_history_action_data" SET to_amount = ? WHERE entry_hash = ? AND tx_index = ? AND tx_index_index = 0`)
+	stmt, err := tx.Prepare(`UPDATE "pn_history_transaction" SET to_amount = ? WHERE entry_hash = ? AND tx_index = ?`)
 	if err != nil {
 		return err
 	}
@@ -243,30 +270,29 @@ func (p *Pegnet) SetTransactionHistoryConvertedAmount(tx *sql.Tx, txbatch *fat2.
 }
 
 func (p *Pegnet) InsertTransactionHistoryTxBatch(tx *sql.Tx, blockorder int, txbatch *fat2.TransactionBatch, height uint32) error {
-	stmt, err := tx.Prepare(`INSERT INTO "pn_transaction_history"
-                (entry_hash, height, timestamp, executed, blockorder) VALUES
+	stmt, err := tx.Prepare(`INSERT INTO "pn_history_txbatch"
+                (entry_hash, height, blockorder, timestamp, executed) VALUES
                 (?, ?, ?, ?, ?)`)
 	if err != nil {
 		return err
 	}
-	_, err = stmt.Exec(txbatch.Entry.Hash[:], height, txbatch.Entry.Timestamp.Unix(), 0, blockorder)
+	_, err = stmt.Exec(txbatch.Entry.Hash[:], height, blockorder, txbatch.Entry.Timestamp.Unix(), 0)
 	if err != nil {
 		return err
 	}
 
-	actionStatement, err := tx.Prepare(`INSERT INTO "pn_transaction_history_action"
-                (entry_hash, tx_index, action_type, address, asset, amount) VALUES
-                (?, ?, ?, ?, ?, ?)`)
+	txStatement, err := tx.Prepare(`INSERT INTO "pn_history_transaction"
+                (entry_hash, tx_index, action_type, from_address, from_asset, from_amount, to_asset, to_amount, outputs) VALUES
+                (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return err
 	}
 
-	actionDataStatement, err := tx.Prepare(`INSERT INTO "pn_transaction_history_action_data"
-                (entry_hash, tx_index, tx_index_index, to_address, to_asset, to_amount) VALUES
-                (?, ?, ?, ?, ?, ?)`)
+	lookup, err := tx.Prepare(insertLookupQuery)
 	if err != nil {
 		return err
 	}
+
 	for index, action := range txbatch.Transactions {
 		var typ HistoryAction
 		if action.IsConversion() {
@@ -275,24 +301,109 @@ func (p *Pegnet) InsertTransactionHistoryTxBatch(tx *sql.Tx, blockorder int, txb
 			typ = Transfer
 		}
 
-		_, err = actionStatement.Exec(txbatch.Entry.Hash[:], index, typ, action.Input.Address[:], action.Input.Type.String(), action.Input.Amount)
-		if err != nil {
+		if _, err = lookup.Exec(txbatch.Entry.Hash[:], index, action.Input.Address[:]); err != nil {
 			return err
 		}
 
 		if action.IsConversion() {
-			_, err = actionDataStatement.Exec(txbatch.Entry.Hash[:], index, 0, action.Input.Address[:], action.Conversion.String(), 0)
+			_, err = txStatement.Exec(txbatch.Entry.Hash[:], index, typ,
+				action.Input.Address[:], action.Input.Type.String(), action.Input.Amount, // from
+				action.Conversion.String(), 0, "") // to
 			if err != nil {
 				return err
 			}
 		} else {
-			for indexindex, data := range action.Transfers {
-				_, err = actionDataStatement.Exec(txbatch.Entry.Hash[:], index, indexindex, data.Address[:], action.Input.Type.String(), data.Amount)
-				if err != nil {
+			outputs := make([]HistoryTransactionOutput, len(action.Transfers))
+			for i, transfer := range action.Transfers {
+				outputs[i] = HistoryTransactionOutput{Address: &transfer.Address, Amount: int64(transfer.Amount)}
+				if _, err = lookup.Exec(txbatch.Entry.Hash[:], index, transfer.Address[:]); err != nil {
 					return err
 				}
 			}
+			var outputData []byte
+			if outputData, err = json.Marshal(outputs); err != nil {
+				return err
+			}
+
+			if _, err = txStatement.Exec(txbatch.Entry.Hash[:], index, typ,
+				action.Input.Address[:], action.Input.Type.String(), action.Input.Amount,
+				"", 0, outputData); err != nil {
+				return err
+			}
 		}
+	}
+
+	return nil
+}
+
+func (p *Pegnet) InsertFCTBurn(tx *sql.Tx, fBlockHash *factom.Bytes32, burn *factom.FactoidTransaction, height uint32) error {
+	stmt, err := tx.Prepare(`INSERT INTO "pn_history_txbatch"
+                (entry_hash, height, blockorder, timestamp, executed) VALUES
+                (?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+
+	lookup, err := tx.Prepare(insertLookupQuery)
+	if err != nil {
+		return err
+	}
+
+	_, err = stmt.Exec(burn.TransactionID[:], height, -1, burn.FactoidTransactionHeader.Timestamp.Unix(), height)
+	if err != nil {
+		return err
+	}
+
+	burnStatement, err := tx.Prepare(`INSERT INTO "pn_history_transaction"
+                (entry_hash, tx_index, action_type, from_address, from_asset, from_amount, to_asset, to_amount, outputs) VALUES
+                (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+
+	if _, err = burnStatement.Exec(burn.TransactionID[:], 0, FCTBurn, burn.FCTInputs[0].Address[:], "FCT", burn.FCTInputs[0].Amount, "pFCT", burn.FCTInputs[0].Amount, ""); err != nil {
+		return err
+	}
+
+	if _, err = lookup.Exec(burn.TransactionID[:], 0, burn.FCTInputs[0].Address[:]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Pegnet) InsertCoinbase(tx *sql.Tx, winner *grader.GradingOPR, addr []byte, timestamp time.Time) error {
+	stmt, err := tx.Prepare(`INSERT INTO "pn_history_txbatch"
+                (entry_hash, height, blockorder, timestamp, executed) VALUES
+                (?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+
+	lookup, err := tx.Prepare(insertLookupQuery)
+	if err != nil {
+		return err
+	}
+
+	_, err = stmt.Exec(winner.EntryHash, winner.OPR.GetHeight(), 0, timestamp.Unix(), winner.OPR.GetHeight())
+	if err != nil {
+		return err
+	}
+
+	coinbaseStatement, err := tx.Prepare(`INSERT INTO "pn_history_transaction"
+                (entry_hash, tx_index, action_type, from_address, from_asset, from_amount, to_asset, to_amount, outputs) VALUES
+                (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+
+	_, err = coinbaseStatement.Exec(winner.EntryHash, 0, Coinbase, addr, "", 0, "PEG", winner.Payout(), "")
+	if err != nil {
+		return err
+	}
+
+	if _, err = lookup.Exec(winner.EntryHash, 0, addr); err != nil {
+		return err
 	}
 
 	return nil

--- a/node/pegnet/txhistory.go
+++ b/node/pegnet/txhistory.go
@@ -1,0 +1,122 @@
+package pegnet
+
+import (
+	"database/sql"
+
+	"github.com/pegnet/pegnetd/fat/fat2"
+)
+
+type HistoryAction int32
+
+const (
+	Transfer HistoryAction = iota
+	Conversion
+	Burn
+)
+const createTableTxHistory = `CREATE TABLE IF NOT EXISTS "pn_transaction_history" (
+	"entry_hash"    BLOB NOT NULL,
+	"height"        INTEGER NOT NULL, -- height the tx is in
+	"txid"     		BLOB NOT NULL,
+	"timestamp"		INTEGER NOT NULL,
+	"executed"		INTEGER NOT NULL, -- -1 if failed, 0 if pending, height it was applied at otherwise
+
+	PRIMARY KEY("entry_hash", "height"),
+	FOREIGN KEY("height") REFERENCES "pn_grade"
+);
+CREATE INDEX IF NOT EXISTS "idx_transaction_history_entry_hash" ON "pn_transaction_history"("entry_hash");
+CREATE INDEX IF NOT EXISTS "idx_transaction_history_txid" ON "pn_transaction_history"("txid");
+CREATE INDEX IF NOT EXISTS "idx_transaction_history_timestamp" ON "pn_transaction_history"("timestamp");
+`
+
+const createTableTxHistoryAction = `CREATE TABLE IF NOT EXISTS "pn_transaction_history_action" (
+	"entry_hash"	BLOB NOT NULL,
+	"tx_index"		INTEGER NOT NULL,	-- the batch index
+	"action_type"	INTEGER NOT NULL,
+	"address"       BLOB NOT NULL,
+	"asset"			STRING NOT NULL,
+	"amount"		INTEGER NOT NULL,
+
+	PRIMARY KEY("entry_hash", "tx_index"),
+	FOREIGN KEY("entry_hash") REFERENCES "pn_transaction_history"
+);
+CREATE INDEX IF NOT EXISTS "idx_transaction_history_address" ON "pn_transaction_history"("address");`
+
+const createTableTxHistoryActionData = `CREATE TABLE IF NOT EXISTS "pn_transaction_history_action_data" (
+	"entry_hash"		BLOB NOT NULL,
+	"tx_index"			INTEGER NOT NULL,	-- the batch index
+	"tx_index_index" 	INTEGER NOT NULL,
+	"to_address"		BLOB NOT NULL,		-- transfer recipient
+	"to_asset"			STRING NOT NULL,	-- conversion/burn
+	"to_amount"			INTEGER NOT NULL,
+	
+	PRIMARY KEY("entry_hash", "tx_index", "tx_index_index"),
+	FOREIGN KEY("entry_hash") REFERENCES "pn_transaction_history"
+);`
+
+func (p *Pegnet) SetTransactionHistoryExecuted(tx *sql.Tx, txbatch *fat2.TransactionBatch, executed int64) error {
+	stmt, err := tx.Prepare(`UPDATE "pn_transaction_history" SET executed = ? WHERE entry_hash = ?`)
+	if err != nil {
+		return err
+	}
+	_, err = stmt.Exec(executed, txbatch.Entry.Hash[:])
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Pegnet) InsertTransactionHistoryTxBatch(tx *sql.Tx, txbatch *fat2.TransactionBatch, height uint32) error {
+	stmt, err := tx.Prepare(`INSERT INTO "pn_transaction_history"
+                (entry_hash, height, txid, timestamp, executed) VALUES
+                (?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+	_, err = stmt.Exec(txbatch.Entry.Hash[:], height, "", txbatch.Entry.Timestamp.Unix(), 0)
+	if err != nil {
+		return err
+	}
+
+	actionStatement, err := tx.Prepare(`INSERT INTO "pn_transaction_history_action"
+                (entry_hash, tx_index, action_type, address, asset, amount) VALUES
+                (?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+
+	actionDataStatement, err := tx.Prepare(`INSERT INTO "pn_transaction_history_action_data"
+                (entry_hash, tx_index, tx_index_index, to_address, to_asset, to_amount) VALUES
+                (?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+	for index, action := range txbatch.Transactions {
+		var typ HistoryAction
+		if action.IsConversion() {
+			typ = Conversion
+		} else {
+			typ = Transfer
+		}
+
+		_, err = actionStatement.Exec(txbatch.Entry.Hash[:], index, typ, action.Input.Address[:], action.Input.Type.String(), action.Input.Amount)
+		if err != nil {
+			return err
+		}
+
+		if action.IsConversion() {
+			_, err = actionDataStatement.Exec(txbatch.Entry.Hash[:], index, 0, "", action.Conversion.String(), 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			for indexindex, data := range action.Transfers {
+				_, err = actionDataStatement.Exec(txbatch.Entry.Hash[:], index, indexindex, data.Address[:], "", data.Amount)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/node/pegnet/txhistory.go
+++ b/node/pegnet/txhistory.go
@@ -47,8 +47,8 @@ type HistoryTransaction struct {
 
 // HistoryTransactionOutput is an entry of a transfer's outputs
 type HistoryTransactionOutput struct {
-	Address *factom.FAAddress `json:"address"`
-	Amount  int64             `json:"amount"`
+	Address factom.FAAddress `json:"address"`
+	Amount  int64            `json:"amount"`
 }
 
 // in the context of tables, `history_txbatch` is the table that holds the unique reference hash
@@ -349,7 +349,7 @@ func (p *Pegnet) InsertTransactionHistoryTxBatch(tx *sql.Tx, blockorder int, txb
 			// json encode the outputs
 			outputs := make([]HistoryTransactionOutput, len(action.Transfers))
 			for i, transfer := range action.Transfers {
-				outputs[i] = HistoryTransactionOutput{Address: &transfer.Address, Amount: int64(transfer.Amount)}
+				outputs[i] = HistoryTransactionOutput{Address: transfer.Address, Amount: int64(transfer.Amount)}
 				if _, err = lookup.Exec(txbatch.Entry.Hash[:], index, transfer.Address[:]); err != nil {
 					return err
 				}

--- a/node/pegnet/txhistory.go
+++ b/node/pegnet/txhistory.go
@@ -2,7 +2,10 @@ package pegnet
 
 import (
 	"database/sql"
+	"fmt"
+	"time"
 
+	"github.com/Factom-Asset-Tokens/factom"
 	"github.com/pegnet/pegnetd/fat/fat2"
 )
 
@@ -16,7 +19,7 @@ const (
 const createTableTxHistory = `CREATE TABLE IF NOT EXISTS "pn_transaction_history" (
 	"entry_hash"    BLOB NOT NULL,
 	"height"        INTEGER NOT NULL, -- height the tx is in
-	"txid"     		BLOB NOT NULL,
+	"blockorder"	INTEGER NOT NULL,
 	"timestamp"		INTEGER NOT NULL,
 	"executed"		INTEGER NOT NULL, -- -1 if failed, 0 if pending, height it was applied at otherwise
 
@@ -24,7 +27,6 @@ const createTableTxHistory = `CREATE TABLE IF NOT EXISTS "pn_transaction_history
 	FOREIGN KEY("height") REFERENCES "pn_grade"
 );
 CREATE INDEX IF NOT EXISTS "idx_transaction_history_entry_hash" ON "pn_transaction_history"("entry_hash");
-CREATE INDEX IF NOT EXISTS "idx_transaction_history_txid" ON "pn_transaction_history"("txid");
 CREATE INDEX IF NOT EXISTS "idx_transaction_history_timestamp" ON "pn_transaction_history"("timestamp");
 `
 
@@ -53,6 +55,169 @@ const createTableTxHistoryActionData = `CREATE TABLE IF NOT EXISTS "pn_transacti
 	FOREIGN KEY("entry_hash") REFERENCES "pn_transaction_history"
 );`
 
+type TxAction struct {
+	Hash      *factom.Bytes32 `json:"hash"`
+	Height    int64           `json:"height"`
+	Timestamp time.Time       `json:"timestamp"`
+	Executed  int32           `json:"executed"`
+	TxIndex   int             `json:"txindex"`
+	TxAction  HistoryAction   `json:"txaction"`
+
+	ActionIndex int               `json:"actionindex"`
+	FromAddress *factom.FAAddress `json:"fromaddress"`
+	FromAsset   string            `json:"fromasset"`
+	FromAmount  int64             `json:"fromamount"`
+	ToAddress   *factom.FAAddress `json:"toaddress"`
+	ToAsset     string            `json:"toasset"`
+	ToAmount    int64             `json:"toamount"`
+}
+
+func _turnRowsIntoTxActions(rows *sql.Rows) ([]TxAction, error) {
+	var actions []TxAction
+	for rows.Next() {
+		var a TxAction
+		var ts int64
+		var hash, from, to []byte
+		err := rows.Scan(
+			&hash, &a.Height, &ts, &a.Executed, // history
+			&a.TxIndex, &a.TxAction, &from, &a.FromAsset, &a.FromAmount, // action
+			&a.ActionIndex, &to, &a.ToAsset, &a.ToAmount) // data
+		if err != nil {
+			return nil, err
+		}
+		a.Hash = factom.NewBytes32(hash)
+		a.Timestamp = time.Unix(ts, 0)
+		var addr1, addr2 factom.FAAddress
+		addr1 = factom.FAAddress(*factom.NewBytes32(from))
+		a.FromAddress = &addr1
+		addr2 = factom.FAAddress(*factom.NewBytes32(to))
+		a.ToAddress = &addr2
+		actions = append(actions, a)
+	}
+	return actions, nil
+}
+
+const baseTxCountQuery = `SELECT COUNT(*) FROM pn_transaction_history history, pn_transaction_history_action action, pn_transaction_history_action_data data
+WHERE history.entry_hash = action.entry_hash AND action.entry_hash = data.entry_hash AND action.tx_index = data.tx_index AND (%s)`
+
+const baseTxActionQuery = `SELECT 
+	history.entry_hash, history.height, history.timestamp, history.executed,
+	action.tx_index, action.action_type, action.address, action.asset, action.amount,
+	data.tx_index_index, data.to_address, data.to_asset, data.to_amount
+FROM pn_transaction_history history, pn_transaction_history_action action, pn_transaction_history_action_data data
+WHERE history.entry_hash = action.entry_hash AND action.entry_hash = data.entry_hash AND action.tx_index = data.tx_index
+	AND (%s)
+ORDER BY %s
+LIMIT 50 OFFSET %d`
+
+func (p *Pegnet) SelectTransactionHistoryActionsByHash(hash *factom.Bytes32, offset int, descending bool) ([]TxAction, int, error) {
+	var count int
+	err := p.DB.QueryRow(fmt.Sprintf(baseTxCountQuery, "history.entry_hash = ?"), hash[:]).Scan(&count)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if count == 0 {
+		return nil, 0, nil
+	}
+
+	if offset > count {
+		return nil, 0, fmt.Errorf("offset too big")
+	}
+
+	order := "history.height, history.blockorder"
+	if descending {
+		order = "history.height DESC, history.blockorder DESC"
+	}
+
+	q := fmt.Sprintf(baseTxActionQuery, "history.entry_hash = ?", order, offset)
+
+	rows, err := p.DB.Query(q, hash[:])
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	a, e := _turnRowsIntoTxActions(rows)
+	return a, count, e
+}
+
+func (p *Pegnet) SelectTransactionHistoryActionsByAddress(addr *factom.FAAddress, offset int, descending bool) ([]TxAction, int, error) {
+	var count int
+	err := p.DB.QueryRow(fmt.Sprintf(baseTxCountQuery, "action.address = ? OR data.to_address = ?"), addr[:], addr[:]).Scan(&count)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if count == 0 {
+		return nil, 0, nil
+	}
+
+	if offset > count {
+		return nil, 0, fmt.Errorf("offset too big")
+	}
+
+	order := "history.height, history.blockorder"
+	if descending {
+		order = "history.height DESC, history.blockorder DESC"
+	}
+
+	q := fmt.Sprintf(baseTxActionQuery, "action.address = ? OR data.to_address = ?", order, offset)
+
+	rows, err := p.DB.Query(q, addr[:], addr[:])
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	a, e := _turnRowsIntoTxActions(rows)
+	return a, count, e
+}
+
+func (p *Pegnet) SelectTransactionHistoryActionsByHeight(height uint32, offset int, descending bool) ([]TxAction, int, error) {
+	var count int
+	err := p.DB.QueryRow(fmt.Sprintf(baseTxCountQuery, "history.height = ?"), height).Scan(&count)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if count == 0 {
+		return nil, 0, nil
+	}
+
+	if offset > count {
+		return nil, 0, fmt.Errorf("offset too big")
+	}
+
+	order := "history.height, history.blockorder"
+	if descending {
+		order = "history.height DESC, history.blockorder DESC"
+	}
+
+	q := fmt.Sprintf(baseTxActionQuery, "history.height = ?", order, offset)
+
+	rows, err := p.DB.Query(q, height)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	a, e := _turnRowsIntoTxActions(rows)
+	return a, count, e
+}
+
+func (p *Pegnet) SelectTransactionHistoryStatus(hash *factom.Bytes32) (uint32, uint32, error) {
+	var height, executed uint32
+	err := p.DB.QueryRow("SELECT height, executed FROM pn_transaction_history WHERE entry_hash = ?", hash[:]).Scan(&height, &executed)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return 0, 0, nil
+		}
+		return 0, 0, err
+	}
+	return height, executed, nil
+}
+
 func (p *Pegnet) SetTransactionHistoryExecuted(tx *sql.Tx, txbatch *fat2.TransactionBatch, executed int64) error {
 	stmt, err := tx.Prepare(`UPDATE "pn_transaction_history" SET executed = ? WHERE entry_hash = ?`)
 	if err != nil {
@@ -65,14 +230,26 @@ func (p *Pegnet) SetTransactionHistoryExecuted(tx *sql.Tx, txbatch *fat2.Transac
 	return nil
 }
 
-func (p *Pegnet) InsertTransactionHistoryTxBatch(tx *sql.Tx, txbatch *fat2.TransactionBatch, height uint32) error {
+func (p *Pegnet) SetTransactionHistoryConvertedAmount(tx *sql.Tx, txbatch *fat2.TransactionBatch, index int, amount int64) error {
+	stmt, err := tx.Prepare(`UPDATE "pn_transaction_history_action_data" SET to_amount = ? WHERE entry_hash = ? AND tx_index = ? AND tx_index_index = 0`)
+	if err != nil {
+		return err
+	}
+	_, err = stmt.Exec(amount, txbatch.Entry.Hash[:], index)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Pegnet) InsertTransactionHistoryTxBatch(tx *sql.Tx, blockorder int, txbatch *fat2.TransactionBatch, height uint32) error {
 	stmt, err := tx.Prepare(`INSERT INTO "pn_transaction_history"
-                (entry_hash, height, txid, timestamp, executed) VALUES
+                (entry_hash, height, timestamp, executed, blockorder) VALUES
                 (?, ?, ?, ?, ?)`)
 	if err != nil {
 		return err
 	}
-	_, err = stmt.Exec(txbatch.Entry.Hash[:], height, "", txbatch.Entry.Timestamp.Unix(), 0)
+	_, err = stmt.Exec(txbatch.Entry.Hash[:], height, txbatch.Entry.Timestamp.Unix(), 0, blockorder)
 	if err != nil {
 		return err
 	}
@@ -104,13 +281,13 @@ func (p *Pegnet) InsertTransactionHistoryTxBatch(tx *sql.Tx, txbatch *fat2.Trans
 		}
 
 		if action.IsConversion() {
-			_, err = actionDataStatement.Exec(txbatch.Entry.Hash[:], index, 0, "", action.Conversion.String(), 0)
+			_, err = actionDataStatement.Exec(txbatch.Entry.Hash[:], index, 0, action.Input.Address[:], action.Conversion.String(), 0)
 			if err != nil {
 				return err
 			}
 		} else {
 			for indexindex, data := range action.Transfers {
-				_, err = actionDataStatement.Exec(txbatch.Entry.Hash[:], index, indexindex, data.Address[:], "", data.Amount)
+				_, err = actionDataStatement.Exec(txbatch.Entry.Hash[:], index, indexindex, data.Address[:], action.Input.Type.String(), data.Amount)
 				if err != nil {
 					return err
 				}

--- a/node/pegnet/txhistory_util.go
+++ b/node/pegnet/txhistory_util.go
@@ -1,0 +1,143 @@
+package pegnet
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Factom-Asset-Tokens/factom"
+)
+
+// HistoryAction are the different types of actions inside the history
+type HistoryAction int32
+
+const (
+	// Invalid is used for debugging
+	Invalid HistoryAction = iota
+	// Transfer is a 1:n transfer of pegged assets from one address to another
+	Transfer
+	// Conversion is a conversion of pegged assets
+	Conversion
+	// Coinbase is a miner reward payout
+	Coinbase
+	// FCTBurn is a pFCT payout for burning FCT on factom
+	FCTBurn
+)
+
+// QueryLimit is the amount of transactions to return in one query
+const QueryLimit = 50
+
+func historyActionPicker(tx, conv, coin, burn bool) []string {
+	if tx == conv && conv == coin && coin == burn {
+		return nil
+	}
+
+	var actions []string
+	if tx {
+		actions = append(actions, strconv.Itoa(int(Transfer)))
+	}
+	if conv {
+		actions = append(actions, strconv.Itoa(int(Conversion)))
+	}
+	if coin {
+		actions = append(actions, strconv.Itoa(int(Coinbase)))
+	}
+	if burn {
+		actions = append(actions, strconv.Itoa(int(FCTBurn)))
+	}
+
+	return actions
+}
+
+// HistoryQueryOptions contains the data of what to query for the query builder
+type HistoryQueryOptions struct {
+	Offset     int
+	Desc       bool
+	Transfer   bool
+	Conversion bool
+	Coinbase   bool
+	FCTBurn    bool
+}
+
+const historyQueryFields = "batch.history_id, batch.entry_hash, batch.height, batch.timestamp, batch.executed," +
+	"tx.tx_index, tx.action_type, tx.from_address, tx.from_asset, tx.from_amount, tx.outputs," +
+	"tx.to_asset, tx.to_amount"
+
+// historyQueryBuilder generates a count and data query for the given options
+func historyQueryBuilder(field string, options HistoryQueryOptions) (string, string, error) {
+	order := "ORDER BY batch.history_id ASC"
+	if options.Desc {
+		order = "ORDER BY batch.history_id DESC"
+	}
+
+	limit := fmt.Sprintf("LIMIT %d OFFSET %d", QueryLimit, options.Offset)
+
+	types := historyActionPicker(options.Transfer, options.Conversion, options.Coinbase, options.FCTBurn)
+
+	var from, where, fromCount, whereCount string
+	switch field {
+	case "address":
+		if types != nil {
+			fromCount = "pn_history_lookup lookup, pn_history_transaction tx"
+			whereCount = "lookup.address = ? AND lookup.entry_hash = tx.entry_hash AND lookup.tx_index = tx.tx_index"
+		} else {
+			fromCount = "pn_history_lookup"
+			whereCount = "address = ?"
+		}
+		from = "pn_history_lookup lookup, pn_history_txbatch batch, pn_history_transaction tx"
+		where = "lookup.address = ? AND lookup.entry_hash = tx.entry_hash AND lookup.tx_index = tx.tx_index AND batch.entry_hash = tx.entry_hash"
+	case "entry_hash":
+		fallthrough
+	case "height":
+		from = "pn_history_txbatch batch, pn_history_transaction tx"
+		where = fmt.Sprintf("batch.entry_hash = tx.entry_hash AND batch.%s = ?", field)
+		fromCount = from
+		whereCount = where
+	default:
+		return "", "", fmt.Errorf("developer error - unimplemented history query builder field")
+	}
+
+	if types != nil {
+		where = fmt.Sprintf("(%s) AND tx.action_type IN(%s)", where, strings.Join(types, ","))
+		whereCount = fmt.Sprintf("(%s) AND tx.action_type IN(%s)", whereCount, strings.Join(types, ","))
+	}
+
+	return fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s", fromCount, whereCount),
+		fmt.Sprintf("SELECT %s FROM %s WHERE %s %s %s", historyQueryFields, from, where, order, limit), nil
+}
+
+// helper function for sql results of a query builder's data query
+func turnRowsIntoHistoryTransactions(rows *sql.Rows) ([]HistoryTransaction, error) {
+	var actions []HistoryTransaction
+	for rows.Next() {
+		var tx HistoryTransaction
+		var ts, id int64
+		var hash, from, outputs []byte
+		err := rows.Scan(
+			&id, &hash, &tx.Height, &ts, &tx.Executed, // history
+			&tx.TxIndex, &tx.TxAction, &from, &tx.FromAsset, &tx.FromAmount, // action
+			&outputs, &tx.ToAsset, &tx.ToAmount) // data
+		if err != nil {
+			return nil, err
+		}
+		tx.Hash = factom.NewBytes32(hash)
+		tx.Timestamp = time.Unix(ts, 0)
+		var addr factom.FAAddress
+		addr = factom.FAAddress(*factom.NewBytes32(from))
+		tx.FromAddress = &addr
+
+		if tx.TxAction == Transfer {
+			var output []HistoryTransactionOutput
+			if err = json.Unmarshal(outputs, &output); err != nil { // should never fail unless database data is corrupt
+				return nil, fmt.Errorf("database corruption %d %v", id, err)
+			}
+			tx.Outputs = output
+		}
+
+		actions = append(actions, tx)
+	}
+	return actions, nil
+}

--- a/node/pegnet/txhistory_util_test.go
+++ b/node/pegnet/txhistory_util_test.go
@@ -1,0 +1,83 @@
+package pegnet
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestHistoryQueryBuilder(t *testing.T) {
+	type args struct {
+		field   string
+		options HistoryQueryOptions
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		want1   string
+		wantErr bool
+	}{ // only a single typed arg suffices since result of types is tested separately below
+		{"empty", args{"", HistoryQueryOptions{}}, "", "", true},
+		{"wrong field", args{"bad", HistoryQueryOptions{}}, "", "", true},
+		{"entry hash, default args", args{"entry_hash", HistoryQueryOptions{}}, "SELECT COUNT(*) FROM pn_history_txbatch batch, pn_history_transaction tx WHERE batch.entry_hash = tx.entry_hash AND batch.entry_hash = ?", "SELECT batch.history_id, batch.entry_hash, batch.height, batch.timestamp, batch.executed,tx.tx_index, tx.action_type, tx.from_address, tx.from_asset, tx.from_amount, tx.outputs,tx.to_asset, tx.to_amount FROM pn_history_txbatch batch, pn_history_transaction tx WHERE batch.entry_hash = tx.entry_hash AND batch.entry_hash = ? ORDER BY batch.history_id ASC LIMIT 50 OFFSET 0", false},
+		{"entry hash, offset", args{"entry_hash", HistoryQueryOptions{Offset: 123}}, "SELECT COUNT(*) FROM pn_history_txbatch batch, pn_history_transaction tx WHERE batch.entry_hash = tx.entry_hash AND batch.entry_hash = ?", "SELECT batch.history_id, batch.entry_hash, batch.height, batch.timestamp, batch.executed,tx.tx_index, tx.action_type, tx.from_address, tx.from_asset, tx.from_amount, tx.outputs,tx.to_asset, tx.to_amount FROM pn_history_txbatch batch, pn_history_transaction tx WHERE batch.entry_hash = tx.entry_hash AND batch.entry_hash = ? ORDER BY batch.history_id ASC LIMIT 50 OFFSET 123", false},
+		{"entry hash, descending", args{"entry_hash", HistoryQueryOptions{Desc: true}}, "SELECT COUNT(*) FROM pn_history_txbatch batch, pn_history_transaction tx WHERE batch.entry_hash = tx.entry_hash AND batch.entry_hash = ?", "SELECT batch.history_id, batch.entry_hash, batch.height, batch.timestamp, batch.executed,tx.tx_index, tx.action_type, tx.from_address, tx.from_asset, tx.from_amount, tx.outputs,tx.to_asset, tx.to_amount FROM pn_history_txbatch batch, pn_history_transaction tx WHERE batch.entry_hash = tx.entry_hash AND batch.entry_hash = ? ORDER BY batch.history_id DESC LIMIT 50 OFFSET 0", false},
+		{"entry hash, typed", args{"entry_hash", HistoryQueryOptions{FCTBurn: true, Coinbase: true}}, "SELECT COUNT(*) FROM pn_history_txbatch batch, pn_history_transaction tx WHERE (batch.entry_hash = tx.entry_hash AND batch.entry_hash = ?) AND tx.action_type IN(3,4)", "SELECT batch.history_id, batch.entry_hash, batch.height, batch.timestamp, batch.executed,tx.tx_index, tx.action_type, tx.from_address, tx.from_asset, tx.from_amount, tx.outputs,tx.to_asset, tx.to_amount FROM pn_history_txbatch batch, pn_history_transaction tx WHERE (batch.entry_hash = tx.entry_hash AND batch.entry_hash = ?) AND tx.action_type IN(3,4) ORDER BY batch.history_id ASC LIMIT 50 OFFSET 0", false},
+		{"height, default args", args{"height", HistoryQueryOptions{}}, "SELECT COUNT(*) FROM pn_history_txbatch batch, pn_history_transaction tx WHERE batch.entry_hash = tx.entry_hash AND batch.height = ?", "SELECT batch.history_id, batch.entry_hash, batch.height, batch.timestamp, batch.executed,tx.tx_index, tx.action_type, tx.from_address, tx.from_asset, tx.from_amount, tx.outputs,tx.to_asset, tx.to_amount FROM pn_history_txbatch batch, pn_history_transaction tx WHERE batch.entry_hash = tx.entry_hash AND batch.height = ? ORDER BY batch.history_id ASC LIMIT 50 OFFSET 0", false},
+		{"address, default args", args{"address", HistoryQueryOptions{}}, "SELECT COUNT(*) FROM pn_history_lookup WHERE address = ?", "SELECT batch.history_id, batch.entry_hash, batch.height, batch.timestamp, batch.executed,tx.tx_index, tx.action_type, tx.from_address, tx.from_asset, tx.from_amount, tx.outputs,tx.to_asset, tx.to_amount FROM pn_history_lookup lookup, pn_history_txbatch batch, pn_history_transaction tx WHERE lookup.address = ? AND lookup.entry_hash = tx.entry_hash AND lookup.tx_index = tx.tx_index AND batch.entry_hash = tx.entry_hash ORDER BY batch.history_id ASC LIMIT 50 OFFSET 0", false},
+		{"address, typed", args{"address", HistoryQueryOptions{Conversion: true, Transfer: true}}, "SELECT COUNT(*) FROM pn_history_lookup lookup, pn_history_transaction tx WHERE (lookup.address = ? AND lookup.entry_hash = tx.entry_hash AND lookup.tx_index = tx.tx_index) AND tx.action_type IN(1,2)", "SELECT batch.history_id, batch.entry_hash, batch.height, batch.timestamp, batch.executed,tx.tx_index, tx.action_type, tx.from_address, tx.from_asset, tx.from_amount, tx.outputs,tx.to_asset, tx.to_amount FROM pn_history_lookup lookup, pn_history_txbatch batch, pn_history_transaction tx WHERE (lookup.address = ? AND lookup.entry_hash = tx.entry_hash AND lookup.tx_index = tx.tx_index AND batch.entry_hash = tx.entry_hash) AND tx.action_type IN(1,2) ORDER BY batch.history_id ASC LIMIT 50 OFFSET 0", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := historyQueryBuilder(tt.args.field, tt.args.options)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("HistoryQueryBuilder() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("HistoryQueryBuilder() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("HistoryQueryBuilder() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func Test_historyActionPicker(t *testing.T) {
+	type args struct {
+		tx   bool
+		conv bool
+		coin bool
+		burn bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{"set-0", args{false, false, false, false}, nil},
+		{"set-1", args{false, false, false, true}, []string{"4"}},
+		{"set-2", args{false, false, true, false}, []string{"3"}},
+		{"set-3", args{false, false, true, true}, []string{"3", "4"}},
+		{"set-4", args{false, true, false, false}, []string{"2"}},
+		{"set-5", args{false, true, false, true}, []string{"2", "4"}},
+		{"set-6", args{false, true, true, false}, []string{"2", "3"}},
+		{"set-7", args{false, true, true, true}, []string{"2", "3", "4"}},
+		{"set-8", args{true, false, false, false}, []string{"1"}},
+		{"set-9", args{true, false, false, true}, []string{"1", "4"}},
+		{"set-10", args{true, false, true, false}, []string{"1", "3"}},
+		{"set-11", args{true, false, true, true}, []string{"1", "3", "4"}},
+		{"set-12", args{true, true, false, false}, []string{"1", "2"}},
+		{"set-13", args{true, true, false, true}, []string{"1", "2", "4"}},
+		{"set-14", args{true, true, true, false}, []string{"1", "2", "3"}},
+		{"set-15", args{true, true, true, true}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := historyActionPicker(tt.args.tx, tt.args.conv, tt.args.coin, tt.args.burn); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("historyActionPicker() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/srv/methods.go
+++ b/srv/methods.go
@@ -117,7 +117,7 @@ func (s *APIServer) getTransactions(data json.RawMessage) interface{} {
 	}
 
 	var res ResultGetTransactions
-	res.Count = len(actions)
+	res.Count = count
 	if params.Offset+len(actions) < count {
 		res.NextOffset = params.Offset + len(actions)
 	}

--- a/srv/methods.go
+++ b/srv/methods.go
@@ -83,6 +83,11 @@ func (s *APIServer) getTransactionStatus(data json.RawMessage) interface{} {
 	return res
 }
 
+// ResultGetTransactions returns history entries.
+// `Actions` contains []pegnet.HistoryTransaction.
+// `Count` is the total number of possible transactions
+// `NextOffset` returns the offset to use to get the next set of records.
+//  0 means no more records available
 type ResultGetTransactions struct {
 	Actions    interface{} `json:"actions"`
 	Count      int         `json:"count"`

--- a/srv/methods.go
+++ b/srv/methods.go
@@ -34,14 +34,17 @@ import (
 	"github.com/pegnet/pegnetd/config"
 	"github.com/pegnet/pegnetd/fat/fat2"
 	"github.com/pegnet/pegnetd/node"
+	"github.com/pegnet/pegnetd/node/pegnet"
 )
 
 func (s *APIServer) jrpcMethods() jrpc.MethodMap {
 	return jrpc.MethodMap{
-		"get-transaction":       s.getTransaction(false),
-		"get-transaction-entry": s.getTransaction(true),
-		"get-pegnet-balances":   s.getPegnetBalances,
-		"get-pegnet-issuance":   s.getPegnetIssuance,
+		"get-transactions":       s.getTransactions,
+		"get-transaction-status": s.getTransactionStatus,
+		"get-transaction":        s.getTransaction(false),
+		"get-transaction-entry":  s.getTransaction(true),
+		"get-pegnet-balances":    s.getPegnetBalances,
+		"get-pegnet-issuance":    s.getPegnetIssuance,
 
 		"send-transaction": s.sendTransaction,
 
@@ -52,11 +55,81 @@ func (s *APIServer) jrpcMethods() jrpc.MethodMap {
 
 }
 
+type ResultGetTransactionStatus struct {
+	Height   uint32 `json:"height"`
+	Executed uint32 `json:"executed"`
+}
+
+func (s *APIServer) getTransactionStatus(data json.RawMessage) interface{} {
+	params := ParamsGetPegnetTransactionStatus{}
+	_, _, err := validate(data, &params)
+	if err != nil {
+		return err
+	}
+
+	height, executed, err := s.Node.Pegnet.SelectTransactionHistoryStatus(params.Hash)
+	if err != nil {
+		return jrpc.InvalidParams(err.Error())
+	}
+
+	if height == 0 {
+		return ErrorTransactionNotFound
+	}
+
+	var res ResultGetTransactionStatus
+	res.Height = height
+	res.Executed = executed
+
+	return res
+}
+
+type ResultGetTransactions struct {
+	Actions    interface{} `json:"actions"`
+	Count      int         `json:"count"`
+	NextOffset int         `json:"nextoffset"`
+}
+
+func (s *APIServer) getTransactions(data json.RawMessage) interface{} {
+	params := ParamsGetPegnetTransaction{}
+	_, _, err := validate(data, &params)
+	if err != nil {
+		return err
+	}
+
+	var actions []pegnet.TxAction
+	var count int
+
+	if params.Hash != nil {
+		actions, count, err = s.Node.Pegnet.SelectTransactionHistoryActionsByHash(params.Hash, params.Offset, params.Desc)
+	} else if params.Address != "" {
+		addr, _ := factom.NewFAAddress(params.Address) // verified in param
+		actions, count, err = s.Node.Pegnet.SelectTransactionHistoryActionsByAddress(&addr, params.Offset, params.Desc)
+	} else {
+		actions, count, err = s.Node.Pegnet.SelectTransactionHistoryActionsByHeight(uint32(params.Height), params.Offset, params.Desc)
+	}
+
+	if err != nil {
+		return jrpc.InvalidParams(err.Error())
+	}
+
+	if len(actions) == 0 {
+		return ErrorTransactionNotFound
+	}
+
+	var res ResultGetTransactions
+	res.Count = len(actions)
+	if params.Offset+len(actions) < count {
+		res.NextOffset = params.Offset + len(actions)
+	}
+	res.Actions = actions
+
+	return res
+}
+
 type ResultGetTransaction struct {
 	Hash      *factom.Bytes32 `json:"entryhash"`
 	Timestamp int64           `json:"timestamp"`
-	TxIndex   uint64          `json:"txindex,omitempty"`
-	Tx        interface{}     `json:"data"`
+	Tx        interface{}     `json:"actions"`
 }
 
 func (s *APIServer) getTransaction(getEntry bool) jrpc.MethodFunc {

--- a/srv/methods.go
+++ b/srv/methods.go
@@ -101,16 +101,25 @@ func (s *APIServer) getTransactions(data json.RawMessage) interface{} {
 		return err
 	}
 
+	// using a separate options struct due to golang's circular import restrictions
+	var options pegnet.HistoryQueryOptions
+	options.Offset = params.Offset
+	options.Desc = params.Desc
+	options.Transfer = params.Transfer
+	options.Conversion = params.Conversion
+	options.Coinbase = params.Coinbase
+	options.FCTBurn = params.Burn
+
 	var actions []pegnet.HistoryTransaction
 	var count int
 
 	if params.Hash != nil {
-		actions, count, err = s.Node.Pegnet.SelectTransactionHistoryActionsByHash(params.Hash, params.Offset, params.Desc)
+		actions, count, err = s.Node.Pegnet.SelectTransactionHistoryActionsByHash(params.Hash, options)
 	} else if params.Address != "" {
 		addr, _ := factom.NewFAAddress(params.Address) // verified in param
-		actions, count, err = s.Node.Pegnet.SelectTransactionHistoryActionsByAddress(&addr, params.Offset, params.Desc)
+		actions, count, err = s.Node.Pegnet.SelectTransactionHistoryActionsByAddress(&addr, options)
 	} else {
-		actions, count, err = s.Node.Pegnet.SelectTransactionHistoryActionsByHeight(uint32(params.Height), params.Offset, params.Desc)
+		actions, count, err = s.Node.Pegnet.SelectTransactionHistoryActionsByHeight(uint32(params.Height), options)
 	}
 
 	if err != nil {

--- a/srv/methods.go
+++ b/srv/methods.go
@@ -96,7 +96,7 @@ func (s *APIServer) getTransactions(data json.RawMessage) interface{} {
 		return err
 	}
 
-	var actions []pegnet.TxAction
+	var actions []pegnet.HistoryTransaction
 	var count int
 
 	if params.Hash != nil {

--- a/srv/params.go
+++ b/srv/params.go
@@ -106,6 +106,11 @@ func (p ParamsGetPegnetTransactionStatus) ValidChainID() *factom.Bytes32 {
 	return nil
 }
 
+// ParamsGetPegnetTransaction are the parameters for retrieving transactions from
+// the history system.
+// You need to specify exactly one of either `hash`, `address`, or `height`.
+// `offset` is the value from a previous query's `nextoffset`.
+// `desc` returns transactions in newest->oldest order
 type ParamsGetPegnetTransaction struct {
 	Hash    *factom.Bytes32 `json:"entryhash,omitempty"`
 	Address string          `json:"address,omitempty"`

--- a/srv/params.go
+++ b/srv/params.go
@@ -112,11 +112,15 @@ func (p ParamsGetPegnetTransactionStatus) ValidChainID() *factom.Bytes32 {
 // `offset` is the value from a previous query's `nextoffset`.
 // `desc` returns transactions in newest->oldest order
 type ParamsGetPegnetTransaction struct {
-	Hash    *factom.Bytes32 `json:"entryhash,omitempty"`
-	Address string          `json:"address,omitempty"`
-	Height  int             `json:"height,omitempty"`
-	Offset  int             `json:"offset,omitempty"`
-	Desc    bool            `json:"desc,omitempty"`
+	Hash       *factom.Bytes32 `json:"entryhash,omitempty"`
+	Address    string          `json:"address,omitempty"`
+	Height     int             `json:"height,omitempty"`
+	Offset     int             `json:"offset,omitempty"`
+	Desc       bool            `json:"desc,omitempty"`
+	Transfer   bool            `json:"transfer,omitempty"`
+	Conversion bool            `json:"conversion,omitempty"`
+	Coinbase   bool            `json:"coinbase,omitempty"`
+	Burn       bool            `json:"burn,omitempty"`
 }
 
 func (p ParamsGetPegnetTransaction) HasIncludePending() bool { return false }

--- a/srv/params.go
+++ b/srv/params.go
@@ -91,6 +91,54 @@ func (ParamsGetPegnetRates) ValidChainID() *factom.Bytes32 {
 	return nil
 }
 
+type ParamsGetPegnetTransactionStatus struct {
+	Hash *factom.Bytes32 `json:"entryhash,omitempty"`
+}
+
+func (p ParamsGetPegnetTransactionStatus) HasIncludePending() bool { return false }
+func (p ParamsGetPegnetTransactionStatus) IsValid() error {
+	if p.Hash == nil {
+		return jrpc.InvalidParams(`required: "entryhash"`)
+	}
+	return nil
+}
+func (p ParamsGetPegnetTransactionStatus) ValidChainID() *factom.Bytes32 {
+	return nil
+}
+
+type ParamsGetPegnetTransaction struct {
+	Hash    *factom.Bytes32 `json:"entryhash,omitempty"`
+	Address string          `json:"address,omitempty"`
+	Height  int             `json:"height,omitempty"`
+	Offset  int             `json:"offset,omitempty"`
+	Desc    bool            `json:"desc,omitempty"`
+}
+
+func (p ParamsGetPegnetTransaction) HasIncludePending() bool { return false }
+func (p ParamsGetPegnetTransaction) IsValid() error {
+	if p.Offset < 0 {
+		return jrpc.InvalidParams(`offset must be >= 0`)
+	}
+	if p.Hash != nil && p.Address != "" && p.Height > 0 {
+		return jrpc.InvalidParams(`required: only set hash or address`)
+	}
+	if p.Hash != nil {
+		return nil
+	} else if p.Address != "" {
+		_, err := factom.NewFAAddress(p.Address)
+		if err != nil {
+			return err
+		}
+		return nil
+	} else if p.Height > 0 {
+		return nil
+	}
+	return jrpc.InvalidParams(`required: "entryhash" or "address"`)
+}
+func (p ParamsGetPegnetTransaction) ValidChainID() *factom.Bytes32 {
+	return nil
+}
+
 type ParamsGetPegnetBalances struct {
 	Address *factom.FAAddress `json:"address,omitempty"`
 }


### PR DESCRIPTION
I implemented a fairly rough tx history requests, but I'm not too sure about the implementation details, so I'm using this PR to get some feedback.

One of the fundamental issues was that a transactions have three dimensions, which meant splitting them up into three tables:

* `pn_transaction_history` this is the factom entryhash itself
* `pn_transaction_history_action` this corresponds to one of the transactions inside the txbatch
* `pn_transaction_history_action_data` this is one of the actions inside a transaction. for conversions there will only be a single one, for transfers there can be > 1

This table gets populated while syncing with all the relevant data (there is some redundancy for sake of ease of use). When a transaction is applied, the row's `executed` value is updated with the height at which it's updated. if there's a balance error, it sets executed to -1. pending conversions are 0.

The API endpoint `get-transaction-status` returns height/executed for a single `entryhash`.
The endpoint `get-transactions` takes a number of parameters:
* either `entryhash`, `address`, or `height`. this gets all of the actions for either one entry, one address, or for a specific height. `address` is both recipient and sender
* `offset`: a value that indicates there are more records. if the result's `nextoffset` is > 0, you can call the same query again but using that value for `offset`
* `desc`: bool. if true it returns results in reverse order

Now the kicker is that this will get individual transactions, not batches. Meaning if a batch has a transaction that sends PEG from one address to 50, it counts those as 50 transactions.
* `count`: the total number of transactions for this api call
* `nextoffset`: the number to use for the next call's `offset`
* `actions`: array of actions (up to 50)

One action is a json object of:
* `hash`: the entryhash
* `height`: height of the entry
* `timestamp`: the time of the entry
* `executed`: block the transaction was executed, -1 if failed, 0 if pending
* `txindex`: the transaction's index inside the batch
* `txaction`: 0 for transfer, 1 for conversion
* `actionindex`: the individual action index in a multi-output transfer (always 0 for conversions)
* `fromaddress`: sending address
* `fromasset`: sent asset type
* `fromamount`: sent amount
* `toaddress:` recipient (always same as fromaddress for conversions)
* `toasset`: target asset type (always the same as fromasset for transfers)
* `toamount`: the target amount (calculated using the actual rate for conversions)

i'm not too sure about this. it's possible to remove `actionindex`, and just make it a list of outputs