### PR TITLE
(TXHistory) Better error messages

### DIFF
--- a/srv/methods.go
+++ b/srv/methods.go
@@ -113,8 +113,10 @@ func (s *APIServer) getTransactions(data json.RawMessage) interface{} {
 	var actions []pegnet.HistoryTransaction
 	var count int
 
-	if params.Hash != nil {
-		actions, count, err = s.Node.Pegnet.SelectTransactionHistoryActionsByHash(params.Hash, options)
+	if params.Hash != "" {
+		hash := new(factom.Bytes32)
+		_ = hash.UnmarshalText([]byte(params.Hash)) // error checked by params.valid
+		actions, count, err = s.Node.Pegnet.SelectTransactionHistoryActionsByHash(hash, options)
 	} else if params.Address != "" {
 		addr, _ := factom.NewFAAddress(params.Address) // verified in param
 		actions, count, err = s.Node.Pegnet.SelectTransactionHistoryActionsByAddress(&addr, options)


### PR DESCRIPTION
Following testing from Veena, this PR improves the error output of the endpoints. Also a bug fix for mutual exclusivity (it only checked if all 3 were present but not if 2 were). The hash parameter now reads strings and tests to see if unmarshaling is possible rather than just throwing an error.