### PR TITLE
add index to history_transaction

### DIFF
--- a/node/pegnet/txhistory.go
+++ b/node/pegnet/txhistory.go
@@ -74,6 +74,7 @@ const createTableTxHistoryTx = `CREATE TABLE IF NOT EXISTS "pn_history_transacti
 	FOREIGN KEY("entry_hash") REFERENCES "pn_history_txbatch"
 );
 CREATE INDEX IF NOT EXISTS "idx_history_transaction_entry_hash" ON "pn_history_transaction"("entry_hash");
+CREATE INDEX IF NOT EXISTS "idx_history_transaction_tx_index" ON "pn_history_transaction"("tx_index");
 `
 
 const createTableTxHistoryLookup = `CREATE TABLE IF NOT EXISTS "pn_history_lookup" (


### PR DESCRIPTION
continuing #82 

you're right about the index.

I used the test query
>EXPLAIN QUERY PLAN SELECT batch.history_id, batch.entry_hash, batch.height, batch.timestamp, batch.executed, tx.tx_index, tx.action_type, tx.from_address, tx.from_asset, tx.from_amount, tx.outputs, tx.to_asset, tx.to_amount FROM pn_history_lookup lookup, pn_history_txbatch batch, pn_history_transaction tx WHERE lookup.address = 'foobar' AND lookup.entry_hash = tx.entry_hash AND lookup.tx_index = tx.tx_index AND batch.entry_hash = tx.entry_hash ORDER BY batch.history_id ASC

to see what it was doing, and got:

![image](https://user-images.githubusercontent.com/34172041/69338607-d864c600-0c63-11ea-94f3-7e68197ea417.png)

SCAN TABLE... not good. The performance for this query was: 
`Result: 0 rows returned in 18996ms`

So I added an index for tx_index, and ran the `EXPLAIN` again:

![image](https://user-images.githubusercontent.com/34172041/69338662-f7635800-0c63-11ea-9f03-0af37f192671.png)


The performance for this query was:
Result: 0 rows returned in 1ms