### PR TITLE
Add PEG conversion limit

### DIFF
--- a/fat/fat2/transaction.go
+++ b/fat/fat2/transaction.go
@@ -170,3 +170,9 @@ func (t *Transaction) Validate() error {
 func (t *Transaction) IsConversion() bool {
 	return len(t.Transfers) == 0 && PTickerInvalid < t.Conversion && t.Conversion < PTickerMax
 }
+
+// IsConversion returns true if this transaction has zero transfers and a
+// valid conversion into PEG
+func (t *Transaction) IsPEGRequest() bool {
+	return len(t.Transfers) == 0 && t.Conversion == PTickerPEG
+}

--- a/fat/fat2/transactionbatch.go
+++ b/fat/fat2/transactionbatch.go
@@ -3,6 +3,7 @@ package fat2
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/Factom-Asset-Tokens/factom"
 	"github.com/Factom-Asset-Tokens/fatd/fat"
 	"github.com/Factom-Asset-Tokens/fatd/fat/jsonlen"
@@ -151,6 +152,16 @@ func (t TransactionBatch) ValidExtIDs() error {
 func (t *TransactionBatch) HasConversions() bool {
 	for _, tx := range t.Transactions {
 		if tx.IsConversion() {
+			return true
+		}
+	}
+	return false
+}
+
+// HasPEGRequest returns if the tx batch has a conversion request into PEG
+func (t *TransactionBatch) HasPEGRequest() bool {
+	for _, tx := range t.Transactions {
+		if tx.IsPEGRequest() {
 			return true
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Factom-Asset-Tokens/factom v0.0.0-20190911201853-7b283996f02a
 	github.com/Factom-Asset-Tokens/fatd v0.6.1-0.20190927200133-81408234a2b5
 	github.com/mattn/go-sqlite3 v1.11.0
-	github.com/pegnet/pegnet v0.1.0-rc4.0.20191127004205-9f6c2c5cc806
+	github.com/pegnet/pegnet v0.1.0-rc4.0.20191127163936-79dd18125075
 	github.com/rs/cors v1.7.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Factom-Asset-Tokens/factom v0.0.0-20190911201853-7b283996f02a
 	github.com/Factom-Asset-Tokens/fatd v0.6.1-0.20190927200133-81408234a2b5
 	github.com/mattn/go-sqlite3 v1.11.0
-	github.com/pegnet/pegnet v0.1.0-rc4.0.20191127163936-79dd18125075
+	github.com/pegnet/pegnet v0.1.0-rc4.0.20191127171923-698416717fd4
 	github.com/rs/cors v1.7.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Factom-Asset-Tokens/factom v0.0.0-20190911201853-7b283996f02a
 	github.com/Factom-Asset-Tokens/fatd v0.6.1-0.20190927200133-81408234a2b5
 	github.com/mattn/go-sqlite3 v1.11.0
-	github.com/pegnet/pegnet v0.1.0-rc4.0.20191105153926-e82140e1ce44
+	github.com/pegnet/pegnet v0.1.0-rc4.0.20191127004205-9f6c2c5cc806
 	github.com/rs/cors v1.7.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
@@ -16,4 +16,4 @@ require (
 	github.com/stretchr/testify v1.4.0
 )
 
-replace github.com/Factom-Asset-Tokens/factom => github.com/Emyrk/factom v0.0.0-20191001194233-40c0cdc2f2a0
+replace github.com/Factom-Asset-Tokens/factom => github.com/Emyrk/factom v0.0.0-20191126234138-6aa6339749f6

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/AdamSLevy/sqlitechangeset v0.0.0-20190925183646-3ddb70fb709d h1:yPm4A
 github.com/AdamSLevy/sqlitechangeset v0.0.0-20190925183646-3ddb70fb709d/go.mod h1:kQNmmf+2gf3uGKHt0LS4guxdp4Ay44SXA4+Is8/Gxm8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Emyrk/factom v0.0.0-20191001194233-40c0cdc2f2a0 h1:blIsTi+ppAojepc46TFXMtHaTMRXI5Ga3cddTC8P0U4=
-github.com/Emyrk/factom v0.0.0-20191001194233-40c0cdc2f2a0/go.mod h1:XbZ9AweH09WKgxrfPIEauJ5/2XL/zroNmDAbd3TdKXk=
+github.com/Emyrk/factom v0.0.0-20191126234138-6aa6339749f6 h1:uHLh0l+G2jHShpxtuYEJOHKfsHIRBZsZvj5b+0iq7A0=
+github.com/Emyrk/factom v0.0.0-20191126234138-6aa6339749f6/go.mod h1:XbZ9AweH09WKgxrfPIEauJ5/2XL/zroNmDAbd3TdKXk=
 github.com/Factom-Asset-Tokens/base58 v0.0.0-20181227014902-61655c4dd885 h1:rfy2fwMrOZPqQgjsH7VCreGMSPzcvqQrfjeSs8nf+sY=
 github.com/Factom-Asset-Tokens/base58 v0.0.0-20181227014902-61655c4dd885/go.mod h1:RVXsRSp6VzXw5l1uiGazuf3qo23Qk0h1HzMcQk+X4LE=
 github.com/Factom-Asset-Tokens/fatd v0.6.1-0.20190927200133-81408234a2b5 h1:nJgckkWLVJxlZyfc5Wv8unMV9QmOQz6InW87MU8x0fg=
@@ -207,8 +207,10 @@ github.com/pegnet/LXRHash v0.0.0-20191028162532-138fe8d191a2 h1:ec8NDi02ydYYKw/R
 github.com/pegnet/LXRHash v0.0.0-20191028162532-138fe8d191a2/go.mod h1:0zBp9GFy9F77zuQbPkAmdUBRiptMaJ1V96eVFdMnXZA=
 github.com/pegnet/OracleRecord v0.0.2/go.mod h1:VrY7Shn4oSCli47CsUYBFjH68IenGYtnLaXaaivepu4=
 github.com/pegnet/pegnet v0.0.2/go.mod h1:FUyEs8fyLOzPXZgyqXcqiOhQi58loNtujykIbxxoKbQ=
-github.com/pegnet/pegnet v0.1.0-rc4.0.20191105153926-e82140e1ce44 h1:vLxdLGSKJUelA++6bBjZte1vyjKv1ZtdemSIdsgJTEo=
-github.com/pegnet/pegnet v0.1.0-rc4.0.20191105153926-e82140e1ce44/go.mod h1:Fy8Qohe9zIuqO9Q/ZOLUNpP2kuiFqxjevzaS3IL62+E=
+github.com/pegnet/pegnet v0.1.0-rc4.0.20191125193202-714f7e8ac93e h1:Dz6qIPZsziJHBtHLUToUDNTZEar0I5Tc1O4vfaA+cRI=
+github.com/pegnet/pegnet v0.1.0-rc4.0.20191125193202-714f7e8ac93e/go.mod h1:Fy8Qohe9zIuqO9Q/ZOLUNpP2kuiFqxjevzaS3IL62+E=
+github.com/pegnet/pegnet v0.1.0-rc4.0.20191127004205-9f6c2c5cc806 h1:t1tkZHWhE5oGOf582Dr4jpez1hceG7UMWX99a9AMxPY=
+github.com/pegnet/pegnet v0.1.0-rc4.0.20191127004205-9f6c2c5cc806/go.mod h1:Fy8Qohe9zIuqO9Q/ZOLUNpP2kuiFqxjevzaS3IL62+E=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/pegnet/pegnet v0.1.0-rc4.0.20191125193202-714f7e8ac93e h1:Dz6qIPZsziJ
 github.com/pegnet/pegnet v0.1.0-rc4.0.20191125193202-714f7e8ac93e/go.mod h1:Fy8Qohe9zIuqO9Q/ZOLUNpP2kuiFqxjevzaS3IL62+E=
 github.com/pegnet/pegnet v0.1.0-rc4.0.20191127004205-9f6c2c5cc806 h1:t1tkZHWhE5oGOf582Dr4jpez1hceG7UMWX99a9AMxPY=
 github.com/pegnet/pegnet v0.1.0-rc4.0.20191127004205-9f6c2c5cc806/go.mod h1:Fy8Qohe9zIuqO9Q/ZOLUNpP2kuiFqxjevzaS3IL62+E=
+github.com/pegnet/pegnet v0.1.0-rc4.0.20191127163936-79dd18125075 h1:ryE4pipoCymprQSdhcXAk5pIUcXGluIfKYO34m0qofU=
+github.com/pegnet/pegnet v0.1.0-rc4.0.20191127163936-79dd18125075/go.mod h1:Fy8Qohe9zIuqO9Q/ZOLUNpP2kuiFqxjevzaS3IL62+E=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/pegnet/pegnet v0.1.0-rc4.0.20191127004205-9f6c2c5cc806 h1:t1tkZHWhE5o
 github.com/pegnet/pegnet v0.1.0-rc4.0.20191127004205-9f6c2c5cc806/go.mod h1:Fy8Qohe9zIuqO9Q/ZOLUNpP2kuiFqxjevzaS3IL62+E=
 github.com/pegnet/pegnet v0.1.0-rc4.0.20191127163936-79dd18125075 h1:ryE4pipoCymprQSdhcXAk5pIUcXGluIfKYO34m0qofU=
 github.com/pegnet/pegnet v0.1.0-rc4.0.20191127163936-79dd18125075/go.mod h1:Fy8Qohe9zIuqO9Q/ZOLUNpP2kuiFqxjevzaS3IL62+E=
+github.com/pegnet/pegnet v0.1.0-rc4.0.20191127171923-698416717fd4 h1:ZAH6iRoLJpr5JqBwkN5hqJ+pfX9aEMooOX/O4BajSNs=
+github.com/pegnet/pegnet v0.1.0-rc4.0.20191127171923-698416717fd4/go.mod h1:Fy8Qohe9zIuqO9Q/ZOLUNpP2kuiFqxjevzaS3IL62+E=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/node/node.go
+++ b/node/node.go
@@ -39,7 +39,7 @@ var (
 	// Once this is activated, a maximum amount of PEG of 5,000 can be
 	// converted per block. At a future height, a dynamic bank should be used.
 	// TODO: Determine this
-	PegnetConversionLimitActivation uint32 = 0
+	PegnetConversionLimitActivation uint32 = 999999
 )
 
 func SetAllActivations(act uint32) {

--- a/node/node.go
+++ b/node/node.go
@@ -36,6 +36,9 @@ var (
 	// Estimated to be Nov 25, 2019 17:47:00 UTC
 	OneWaypFCTConversions uint32 = 220346
 
+	// Once this is activated, a maximum amount of PEG of 5,000 can be
+	// converted per block. At a future height, a dynamic bank should be used.
+	// TODO: Determine this
 	PegnetConversionLimitActivation uint32 = 0
 )
 

--- a/node/node.go
+++ b/node/node.go
@@ -35,6 +35,8 @@ var (
 	// The only way to aquire pFCT is to burn FCT. The burn command will remain.
 	// Estimated to be Nov 25, 2019 17:47:00 UTC
 	OneWaypFCTConversions uint32 = 220346
+
+	PegnetConversionLimitActivation uint32 = 0
 )
 
 func SetAllActivations(act uint32) {

--- a/node/pegnet/transaction_test.go
+++ b/node/pegnet/transaction_test.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/pegnet/pegnet/modules/conversions"
 	. "github.com/pegnet/pegnetd/node/pegnet"
 	"github.com/stretchr/testify/assert"
 )
@@ -113,108 +112,6 @@ func TestVerifyTransactionHash(t *testing.T) {
 				assert.Equal(exp, vec.TxID)
 			}
 		} else {
-		}
-	}
-}
-
-func TestPEGSupplyConversions(t *testing.T) {
-	min := func(a, b int64) int64 {
-		if a < b {
-			return a
-		}
-		return b
-	}
-
-	// Currently the PEG supply limit yields are calculated as such:
-	// amt pXXX -> yielded PEG + refund pXXX
-	t.Run("test equivalency", func(t *testing.T) {
-		for i := 0; i < 1; i++ {
-			amtR := rand.Uint64() % (5 * 1e6 * 1e8) // 50K max
-			pegR := rand.Uint64() % (5 * 1e6 * 1e8) // 50K max
-
-			input := rand.Int63() % (1 * 1e6 * 1e8) // 1million max
-			_, err := conversions.Convert(int64(input), amtR, pegR)
-			if err != nil {
-				continue // Likely an overflow or rate is 0
-			}
-
-			// Most yield possibilities for a 5K bank
-			for yield := int64(1); yield <= min(input, 5000*1e8); yield = yield + (rand.Int63() % 1e8) {
-				// 2 methods to calculate the refund. We have:
-				// Input in pXXX, yield in PEG
-
-				refund := RefundMethod2(t, input, yield, amtR, pegR)
-				CheckRefund(t, input, refund, yield, amtR, pegR)
-			}
-		}
-	})
-}
-
-// RefundMethod1 is the following:
-// maxPEGYield := (input -> PEG)
-// refundPEG := maxPEGYield - PEGYield
-// refuind := (refundPEG -> pXXX)
-func RefundMethod1(t *testing.T, input, pegYield int64, amtRate, pegRate uint64) int64 {
-	maxPEGYield, _ := conversions.Convert(input, amtRate, pegRate)
-	refundPEG := maxPEGYield - pegYield
-	refund, _ := conversions.Convert(refundPEG, pegRate, amtRate)
-	return refund
-}
-
-// RefundMethod2 is the following:
-// consumedInput := (pegYield -> pXXX)
-// refund := input - consumedInput
-func RefundMethod2(t *testing.T, input, pegYield int64, amtRate, pegRate uint64) int64 {
-	consumedInput, _ := conversions.Convert(pegYield, pegRate, amtRate)
-	refund := input - consumedInput
-	return refund
-}
-
-// CheckRefund
-// amt is in pXXX
-// refund is in pXXX
-// pegYield is in PEG
-func CheckRefund(t *testing.T, input, refund, pegYield int64, amtRate, pegRate uint64) {
-	maxPegYield, err := conversions.Convert(input, amtRate, pegRate)
-	if err != nil {
-		return // Overflow or 0 rates
-	}
-
-	{
-		// Asset Equivalency
-		// This check is `input = refund + (peg converted to input)`
-		yieldInAsset, err := conversions.Convert(pegYield, pegRate, amtRate)
-		if err != nil {
-			t.Error(err) // This would be bad news
-		}
-
-		if refund+yieldInAsset != int64(input) {
-			t.Errorf("input = refund + (yield PEG -> pXXX) does not hold true\n"+
-				"Amt: %d, Refund: %d, Add: %d\n"+
-				"Difference: %d", input, refund, yieldInAsset, int64(input)-(refund+yieldInAsset))
-		}
-	}
-
-	{
-		// PEG Equivalency
-		// This check is
-		// consumed = input - refund
-		// consumed -> PEG + refund -> PEG = input -> PEG
-		consumed := int64(input) - refund
-		consumedPEG, err := conversions.Convert(consumed, amtRate, pegRate)
-		if err != nil {
-			t.Error(err) // This would be bad news
-		}
-
-		refundPEGCheck, err := conversions.Convert(refund, amtRate, pegRate)
-		if err != nil {
-			t.Error(err) // This would be bad news
-		}
-
-		// We allow a difference of +1. This means the consumed + refund is
-		// 1 less than the max. Which is ok, and expected
-		if maxPegYield-(consumedPEG+refundPEGCheck) > 1 {
-			t.Errorf("Failed PEG equivalency: %d", maxPegYield-(consumedPEG+refundPEGCheck))
 		}
 	}
 }

--- a/node/pegnet/txhistory_util.go
+++ b/node/pegnet/txhistory_util.go
@@ -152,7 +152,13 @@ func turnRowsIntoHistoryTransactions(rows *sql.Rows) ([]HistoryTransaction, erro
 		addr = factom.FAAddress(*factom.NewBytes32(from))
 		tx.FromAddress = &addr
 
-		if tx.TxAction == Transfer {
+		// Conversions into PEG
+		if tx.TxAction == Transfer || tx.ToAsset == "PEG" {
+			if tx.ToAsset == "PEG" && len(outputs) == 0 {
+				// If before the activation height, there is no json marshal
+				// here.
+				outputs = []byte("[]")
+			}
 			var output []HistoryTransactionOutput
 			if err = json.Unmarshal(outputs, &output); err != nil { // should never fail unless database data is corrupt
 				return nil, fmt.Errorf("database corruption %d %v", id, err)

--- a/node/sync.go
+++ b/node/sync.go
@@ -611,6 +611,7 @@ func (d *Pegnetd) recordPegnetRequests(sqlTx *sql.Tx, txBatchs []*fat2.Transacti
 			"txindex":         txData[txid].TxIndex,
 			"refund":          refundAmt,
 			"pegyield":        pegYield,
+			"inputtype":       tx.Input.Type.String(),
 		}).Tracef("refund set")
 
 		if err := d.Pegnet.SetTransactionHistoryPEGConvertedRequestAmount(sqlTx, txData[txid].Batch, txData[txid].TxIndex, int64(pegYield), refundAmt); err != nil {

--- a/node/sync.go
+++ b/node/sync.go
@@ -607,6 +607,7 @@ func (d *Pegnetd) recordPegnetRequests(sqlTx *sql.Tx, txBatchs []*fat2.Transacti
 
 		log.WithFields(log.Fields{
 			"batch-entryhash": txData[txid].Batch.Entry.Hash.String(),
+			"height":          currentHeight,
 			"txid":            txid,
 			"txindex":         txData[txid].TxIndex,
 			"refund":          refundAmt,

--- a/node/sync.go
+++ b/node/sync.go
@@ -605,6 +605,14 @@ func (d *Pegnetd) recordPegnetRequests(sqlTx *sql.Tx, txBatchs []*fat2.Transacti
 
 		refundAmt := conversions.Refund(int64(tx.Input.Amount), int64(pegYield), rates[tx.Input.Type], rates[tx.Conversion])
 
+		log.WithFields(log.Fields{
+			"batch-entryhash": txData[txid].Batch.Entry.Hash.String(),
+			"txid":            txid,
+			"txindex":         txData[txid].TxIndex,
+			"refund":          refundAmt,
+			"pegyield":        pegYield,
+		}).Tracef("refund set")
+
 		if err := d.Pegnet.SetTransactionHistoryPEGConvertedRequestAmount(sqlTx, txData[txid].Batch, txData[txid].TxIndex, int64(pegYield), refundAmt); err != nil {
 			return err
 		}

--- a/node/sync.go
+++ b/node/sync.go
@@ -527,7 +527,7 @@ func (d *Pegnetd) recordBatch(sqlTx *sql.Tx, txBatch *fat2.TransactionBatch, rat
 			if err != nil {
 				return err
 			}
-			return nil // PEG Outputs are handled elsewhere
+			continue // PEG Outputs are handled elsewhere
 		}
 
 		// Outputs


### PR DESCRIPTION
5K Limit per block

To reflect the conversion refunds, I use the transfer outputs section. E.g
```
{
  "actions": [
    {
      "executed": 131,
      "fromaddress": "FA2w3564a1vuLqUbiwG8EB8anJJdyRyihArcBgjsfPSnyktMNFsy",
      "fromamount": 10000000000,
      "fromasset": "pFCT",
      "hash": "34b97883391294767dd0b781767ac4c825bad94e2e20141b0eb0bc461306dcdf",
      "height": 130,
      "outputs": [
        {
          "address": "FA2w3564a1vuLqUbiwG8EB8anJJdyRyihArcBgjsfPSnyktMNFsy",
          "amount": 9299712223
        }
      ],
      "timestamp": "2019-11-26T17:47:00-06:00",
      "toamount": 250000000000,
      "toasset": "PEG",
      "txaction": 2,
      "txid": "0-34b97883391294767dd0b781767ac4c825bad94e2e20141b0eb0bc461306dcdf",
      "txindex": 0
    }
  ],
  "count": 1,
  "nextoffset": 0
}
```