### PR TITLE
Rich list API request and cli command

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -82,7 +82,7 @@ func assetRich(cl *srv.Client, asset string, count int) {
 	params.Asset = asset
 	params.Count = count
 
-	var res srv.ResultGetRichList
+	var res []srv.ResultGetRichList
 	err := cl.Request("get-rich-list", params, &res)
 	if err != nil {
 		fmt.Println(err)
@@ -93,7 +93,7 @@ func assetRich(cl *srv.Client, asset string, count int) {
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(tw, "Pos\tAddress\t%s\tpUSD\t\n", asset)
 	fmt.Fprintf(tw, "---\t-------\t%s\t----\t\n", strings.Repeat("-", len(asset)))
-	for i, e := range res.List {
+	for i, e := range res {
 		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t\n", i+1, e.Address, FactoshiToFactoid(int64(e.Amount)), FactoshiToFactoid(int64(e.Equiv)))
 	}
 	tw.Flush()

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/Factom-Asset-Tokens/factom"
@@ -26,6 +27,8 @@ func init() {
 	rootCmd.AddCommand(issuance)
 	rootCmd.AddCommand(status)
 	rootCmd.AddCommand(burn)
+	rich.Flags().Int("count", 100, "The top X address")
+	rootCmd.AddCommand(rich)
 
 	get.AddCommand(getTX)
 	get.AddCommand(getRates)
@@ -43,6 +46,78 @@ func init() {
 	rootCmd.AddCommand(tx)
 	rootCmd.AddCommand(conv)
 
+}
+
+var rich = &cobra.Command{
+	Use:              "richlist [ASSET]",
+	Short:            "Get a list of richest addresses",
+	Example:          "richlist PEG --count=1",
+	PersistentPreRun: always,
+	PreRun:           SoftReadConfig,
+	Args:             cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		cl := srv.NewClient()
+		cl.PegnetdServer = viper.GetString(config.Pegnetd)
+		count, _ := cmd.Flags().GetInt("count")
+		if count == 0 {
+			count = 100
+		}
+
+		if len(args) > 0 {
+			ticker := fat2.StringToTicker(args[0])
+			if ticker == fat2.PTickerInvalid {
+				cmd.PrintErrln(fmt.Errorf("invalid asset specified"))
+				os.Exit(1)
+			}
+
+			assetRich(cl, ticker.String(), count)
+		} else {
+			globalRich(cl, count)
+		}
+	},
+}
+
+func assetRich(cl *srv.Client, asset string, count int) {
+	var params srv.ParamsGetRichList
+	params.Asset = asset
+	params.Count = count
+
+	var res srv.ResultGetRichList
+	err := cl.Request("get-rich-list", params, &res)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Top %d %s Rich List\n", count, asset)
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "Pos\tAddress\t%s\tpUSD\t\n", asset)
+	fmt.Fprintf(tw, "---\t-------\t%s\t----\t\n", strings.Repeat("-", len(asset)))
+	for i, e := range res.List {
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t\n", i+1, e.Address, FactoshiToFactoid(int64(e.Amount)), FactoshiToFactoid(int64(e.Equiv)))
+	}
+	tw.Flush()
+}
+
+func globalRich(cl *srv.Client, count int) {
+	var params srv.ParamsGetGlobalRichList
+	params.Count = count
+
+	var res []srv.ResultGlobalRichList
+	err := cl.Request("get-global-rich-list", params, &res)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Top %d Global Rich List\n", count)
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "Pos\tAddress\tpUSD\t\n")
+	fmt.Fprintf(tw, "---\t-------\t----\t\n")
+	for i, e := range res {
+		fmt.Fprintf(tw, "%d\t%s\t%s\t\n", i+1, e.Address, FactoshiToFactoid(int64(e.Equiv)))
+	}
+	tw.Flush()
 }
 
 var burn = &cobra.Command{

--- a/node/pegnet/grading.go
+++ b/node/pegnet/grading.go
@@ -168,7 +168,7 @@ func (p *Pegnet) SelectRatesByKeyMR(ctx context.Context, keymr *factom.Bytes32) 
 	return _extractAssets(rows)
 }
 
-func (p *Pegnet) SelectMostRecentRatesBeforeHeight(ctx context.Context, tx *sql.Tx, height uint32) (map[fat2.PTicker]uint64, uint32, error) {
+func (p *Pegnet) SelectMostRecentRatesBeforeHeight(ctx context.Context, tx QueryAble, height uint32) (map[fat2.PTicker]uint64, uint32, error) {
 	assets := make(map[fat2.PTicker]uint64)
 	var rateHeight uint32
 	queryString := `SELECT "token", "value", "height"

--- a/srv/methods.go
+++ b/srv/methods.go
@@ -127,10 +127,6 @@ func (s *APIServer) getGlobalRichList(data json.RawMessage) interface{} {
 }
 
 type ResultGetRichList struct {
-	Asset string      `json:"asset"`
-	List  []RichEntry `json:"list"`
-}
-type RichEntry struct {
 	Address string `json:"address"`
 	Amount  uint64 `json:"amount"`
 	Equiv   uint64 `json:"pusd"`
@@ -160,11 +156,9 @@ func (s *APIServer) getRichList(data json.RawMessage) interface{} {
 		return err
 	}
 
-	var res ResultGetRichList
-	res.Asset = ticker.String()
-
+	var res []ResultGetRichList
 	for _, r := range rich {
-		var entry RichEntry
+		var entry ResultGetRichList
 		entry.Address = r.Address.String()
 		entry.Amount = r.Balance
 		c, err := conversions.Convert(int64(r.Balance), rates[ticker], rates[fat2.PTickerUSD])
@@ -173,7 +167,7 @@ func (s *APIServer) getRichList(data json.RawMessage) interface{} {
 		}
 		entry.Equiv = uint64(c)
 
-		res.List = append(res.List, entry)
+		res = append(res, entry)
 	}
 
 	return res

--- a/srv/methods.go
+++ b/srv/methods.go
@@ -75,9 +75,14 @@ func (s *APIServer) getGlobalRichList(data json.RawMessage) interface{} {
 	}
 
 	height := s.Node.GetCurrentSync()
-	rates, err := s.Node.Pegnet.SelectRates(nil, height)
+	rates, realHeight, err := s.Node.Pegnet.SelectMostRecentRatesBeforeHeight(nil, s.Node.Pegnet.DB, height+1)
 	if err != nil {
 		return err
+	}
+
+	res := make([]ResultGlobalRichList, 0)
+	if realHeight == 0 {
+		return res
 	}
 
 	rich, err := s.Node.Pegnet.SelectAllBalances()
@@ -85,7 +90,6 @@ func (s *APIServer) getGlobalRichList(data json.RawMessage) interface{} {
 		return err
 	}
 
-	var res []ResultGlobalRichList
 	for _, r := range rich {
 		var usd uint64
 
@@ -120,9 +124,6 @@ func (s *APIServer) getGlobalRichList(data json.RawMessage) interface{} {
 		res = res[:params.Count]
 	}
 
-	if len(res) == 0 {
-		return []ResultGlobalRichList{}
-	}
 	return res
 }
 
@@ -144,7 +145,7 @@ func (s *APIServer) getRichList(data json.RawMessage) interface{} {
 	}
 
 	height := s.Node.GetCurrentSync()
-	rates, err := s.Node.Pegnet.SelectRates(nil, height)
+	rates, rateHeight, err := s.Node.Pegnet.SelectMostRecentRatesBeforeHeight(nil, s.Node.Pegnet.DB, height+1)
 	if err != nil {
 		return err
 	}
@@ -156,16 +157,18 @@ func (s *APIServer) getRichList(data json.RawMessage) interface{} {
 		return err
 	}
 
-	var res []ResultGetRichList
+	res := make([]ResultGetRichList, 0)
 	for _, r := range rich {
 		var entry ResultGetRichList
 		entry.Address = r.Address.String()
 		entry.Amount = r.Balance
-		c, err := conversions.Convert(int64(r.Balance), rates[ticker], rates[fat2.PTickerUSD])
-		if err != nil {
-			return err
+		if rateHeight > 0 {
+			c, err := conversions.Convert(int64(r.Balance), rates[ticker], rates[fat2.PTickerUSD])
+			if err != nil {
+				return err
+			}
+			entry.Equiv = uint64(c)
 		}
-		entry.Equiv = uint64(c)
 
 		res = append(res, entry)
 	}

--- a/srv/params.go
+++ b/srv/params.go
@@ -39,6 +39,41 @@ type Params interface {
 	HasIncludePending() bool
 }
 
+type ParamsGetGlobalRichList struct {
+	Count int `json:"count,omitempty"`
+}
+
+func (p ParamsGetGlobalRichList) HasIncludePending() bool { return false }
+func (p ParamsGetGlobalRichList) IsValid() error {
+	if p.Count < 0 {
+		return jrpc.InvalidParams("count must be >= 0")
+	}
+	return nil
+}
+func (p ParamsGetGlobalRichList) ValidChainID() *factom.Bytes32 {
+	return nil
+}
+
+type ParamsGetRichList struct {
+	Asset string `json:"asset,omitempty"`
+	Count int    `json:"count,omitempty"`
+}
+
+func (p ParamsGetRichList) HasIncludePending() bool { return false }
+func (p ParamsGetRichList) IsValid() error {
+	ticker := fat2.StringToTicker(p.Asset)
+	if ticker == fat2.PTickerInvalid {
+		return jrpc.InvalidParams("invalid asset")
+	}
+	if p.Count < 0 {
+		return jrpc.InvalidParams("count must be >= 0")
+	}
+	return nil
+}
+func (p ParamsGetRichList) ValidChainID() *factom.Bytes32 {
+	return nil
+}
+
 // ParamsToken scopes a request down to a single FAT token using either the
 // ChainID or both the TokenID and the IssuerChainID.
 type ParamsToken struct {


### PR DESCRIPTION
Was doing this for PNMC, figured I might as well include the functionality in the cli.

Adds two api calls:
* get-rich-list which takes `count` and `asset` (count default is 100)
* get-global-rich-list which takes `count` (count default is 100)

I separated them because the logic for each is much different. Calculating the global rich list is more expensive than an asset rich list because I'm doing the conversions and sorting after the query. It is theoretically possible to build a query that does the conversions but due to the structure of the table, this was far easier to implement.

The asset-rich list returns a list of the top X addresses, the asset balance, and the pUSD equivalent value. The global list adds up the pUSD equivalent of all assets of that address and only returns the pUSD equivalent sum.