### PR TITLE
EntryHash should be a blob, not an integer

### DIFF
--- a/node/pegnet/txhistory.go
+++ b/node/pegnet/txhistory.go
@@ -78,7 +78,7 @@ CREATE INDEX IF NOT EXISTS "idx_history_transaction_tx_index" ON "pn_history_tra
 `
 
 const createTableTxHistoryLookup = `CREATE TABLE IF NOT EXISTS "pn_history_lookup" (
-	"entry_hash"	INTEGER NOT NULL,
+	"entry_hash"	BLOB NOT NULL,
 	"tx_index"		INTEGER NOT NULL,
 	"address"		BLOB NOT NULL,
 


### PR DESCRIPTION
Should we write a rule to convert the table to a blob if it's found to be an integer?  A migration to prevent a resync