### PR TITLE
TX History Lookup: Change entry hash from integer to blob

### DIFF
--- a/node/pegnet/pegnet.go
+++ b/node/pegnet/pegnet.go
@@ -84,6 +84,10 @@ func (p *Pegnet) createTables() error {
 			return err
 		}
 	}
+
+	// migrate pn_history_lookup alter column
+	txhistoryMigrateLookup1(p)
+
 	return nil
 }
 


### PR DESCRIPTION
close: #92 

This PR encompasses #92 and also includes DB migration for older databases. At startup, the node will check the structure of pn_history_lookup and attempt migration if the entry_hash column is an integer. 

I opted for an anonymous function so I could place the migration SQL statement close to the creation statement.