### PR TITLE
Implement a version checking function for hard forks

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,7 @@ func init() {
 	rootCmd.Flags().Bool("wal", false, "Turn on WAL mode for sqlite")
 
 	rootCmd.PersistentFlags().BoolP("no-warn", "n", false, "Ignore all warnings/notices")
+	rootCmd.PersistentFlags().Bool("no-hf", false, "Disable the check that your node was updated before each hard fork. It will still print a warning")
 
 	// This is for testing purposes
 	rootCmd.PersistentFlags().Bool("testing", false, "If this flag is set, all activations heights are set to 0.")
@@ -177,6 +178,7 @@ func always(cmd *cobra.Command, args []string) {
 	_ = viper.BindPFlag(config.APIListen, cmd.Flags().Lookup("api"))
 	_ = viper.BindPFlag(config.SQLDBWalMode, cmd.Flags().Lookup("wal"))
 	_ = viper.BindPFlag(config.CustomSQLDBMode, cmd.Flags().Lookup("dbmode"))
+	_ = viper.BindPFlag(config.DisableHardForkCheck, cmd.Flags().Lookup("no-hf"))
 
 	// Also init some defaults
 	viper.SetDefault(config.DBlockSyncRetryPeriod, time.Second*5)

--- a/config/locations.go
+++ b/config/locations.go
@@ -12,10 +12,11 @@ const (
 	CustomSQLDBMode = "db.mode"
 	SQLDBWalMode    = "db.wal"
 
-	Server       = "app.Server"
-	Wallet       = "app.Wallet"
-	WalletUser   = "app.WalletUser"
-	WalletPass   = "app.WalletPass"
-	Pegnetd      = "app.Pegnetd"
-	ECPrivateKey = "app.ECPrivateKey"
+	Server               = "app.Server"
+	Wallet               = "app.Wallet"
+	WalletUser           = "app.WalletUser"
+	WalletPass           = "app.WalletPass"
+	Pegnetd              = "app.Pegnetd"
+	ECPrivateKey         = "app.ECPrivateKey"
+	DisableHardForkCheck = "app.DisableHardForkCheck"
 )

--- a/node/node.go
+++ b/node/node.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/Factom-Asset-Tokens/factom"
 	_ "github.com/mattn/go-sqlite3"
@@ -87,6 +88,16 @@ func NewPegnetd(ctx context.Context, conf *viper.Viper) (*Pegnetd, error) {
 		}
 	} else {
 		n.Sync = sync
+	}
+
+	err := n.Pegnet.CheckHardForks(n.Pegnet.DB)
+	if err != nil {
+		err = fmt.Errorf("pegnetd database hardfork check failed: %s", err.Error())
+		if conf.GetBool(config.DisableHardForkCheck) {
+			log.Warnf(err.Error())
+		} else {
+			return nil, err
+		}
 	}
 
 	grader.InitLX()

--- a/node/pegnet/admin.go
+++ b/node/pegnet/admin.go
@@ -86,14 +86,20 @@ func (Pegnet) HighestSynced(tx QueryAble) (uint32, error) {
 func (Pegnet) FetchMinSyncedVersion(tx QueryAble, height uint32) (int, error) {
 	var version int
 	err := tx.QueryRow(`SELECT COALESCE(MIN(version), -1) FROM pn_sync_version WHERE height >= ?;`, height).Scan(&version)
-	return version, err
+	if err != nil {
+		return -1, err
+	}
+	return version, nil
 }
 
 // FetchMaxSyncedVersion returns -1, nil if the height was not found
 func (Pegnet) FetchMaxSyncedVersion(tx QueryAble, height uint32) (int, error) {
 	var version int
 	err := tx.QueryRow(`SELECT COALESCE(MAX(version), -1) FROM pn_sync_version WHERE height >= ?;`, height).Scan(&version)
-	return version, err
+	if err != nil {
+		return -1, err
+	}
+	return version, nil
 }
 
 // CheckHardForks will iterate over all the hardforks post the version_lock

--- a/node/pegnet/admin.go
+++ b/node/pegnet/admin.go
@@ -86,9 +86,6 @@ func (Pegnet) HighestSynced(tx QueryAble) (uint32, error) {
 func (Pegnet) FetchMinSyncedVersion(tx QueryAble, height uint32) (int, error) {
 	var version int
 	err := tx.QueryRow(`SELECT COALESCE(MIN(version), -1) FROM pn_sync_version WHERE height >= ?;`, height).Scan(&version)
-	if err == sql.ErrNoRows {
-		return -1, nil
-	}
 	return version, err
 }
 
@@ -96,9 +93,6 @@ func (Pegnet) FetchMinSyncedVersion(tx QueryAble, height uint32) (int, error) {
 func (Pegnet) FetchMaxSyncedVersion(tx QueryAble, height uint32) (int, error) {
 	var version int
 	err := tx.QueryRow(`SELECT COALESCE(MAX(version), -1) FROM pn_sync_version WHERE height >= ?;`, height).Scan(&version)
-	if err == sql.ErrNoRows {
-		return -1, nil
-	}
 	return version, err
 }
 

--- a/node/pegnet/admin.go
+++ b/node/pegnet/admin.go
@@ -1,0 +1,120 @@
+package pegnet
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// This file can be used for node administration related functions
+
+var (
+	// PegnetdSyncVersion is an indicator of the version of pegnetd
+	// at each height synced. This version number can differ from the tagged
+	// version, and is likely only to be updated at hard forks. It is used to
+	// detect if a pegnetd was updated late, and therefore has an invalid state.
+	//
+	// Each fork should increment this number by at least 1
+	PegnetdSyncVersion = 1
+)
+
+type ForkEvent struct {
+	ActivationHeight uint32
+	MinimumVersion   int
+}
+
+var (
+	Hardforks = []ForkEvent{
+		// This is the most basic check. All versions are valid for 0
+		{0, -1}, // {0, -1}, means at height 0 any version >= -1 is sufficient
+
+		// Pegnet activation. When Pegnet starts on mainnet
+		{206422, 1},
+
+		// Future hardforks go here
+		// If the pegnet node syncs a hardfork height with any height less than
+		// the minimum version, the node will not start.
+	}
+)
+
+// createTableSyncVersion is a SQL string that creates the
+// "pn_sync_version" table. This table tracks which heights are synced
+// with what version of pegnetd. This will allow pegnetd to detect if
+// it was updated before or after a hardfork and respond appropriately.
+const createTableSyncVersion = `CREATE TABLE IF NOT EXISTS "pn_sync_version" (
+        "height"    		INTEGER NOT NULL,
+        "version"       	INTEGER NOT NULL,
+        "unix_timestamp"	INTEGER NOT NULL,
+
+        PRIMARY KEY("height")
+);
+`
+
+// CreateTableSyncVersion is used to expose this table for unit tests
+func (p *Pegnet) CreateTableSyncVersion() error {
+	_, err := p.DB.Exec(createTableSyncVersion)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (Pegnet) MarkHeightSynced(tx QueryAble, height uint32) error {
+	stmtStringFmt := `INSERT INTO "pn_sync_version" 
+			("height", "version", "unix_timestamp")
+			VALUES (?, ?, ?);`
+
+	stmt, err := tx.Prepare(stmtStringFmt)
+	if err != nil {
+		return err
+	}
+
+	_, err = stmt.Exec(height, PegnetdSyncVersion, time.Now().Unix())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (Pegnet) HighestSynced(tx QueryAble) (uint32, error) {
+	var topHeight uint32
+	err := tx.QueryRow(`SELECT COALESCE(max(height), 0) FROM pn_sync_version;`).Scan(&topHeight)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	return topHeight, err
+}
+
+// FetchSyncedVersion returns -1, nil if the height was not found
+func (Pegnet) FetchSyncedVersion(tx QueryAble, height uint32) (int, error) {
+	var version int
+	err := tx.QueryRow(`SELECT version FROM pn_sync_version WHERE height = ?;`, height).Scan(&version)
+	if err == sql.ErrNoRows {
+		return -1, nil
+	}
+	return version, err
+}
+
+// CheckHardForks will iterate over all the hardforks post the version_lock
+// update, and verify the version that was used to sync was appropriate.
+func (p Pegnet) CheckHardForks(tx QueryAble) error {
+	top, err := p.HighestSynced(tx)
+	if err != nil {
+		return err
+	}
+
+	for _, event := range Hardforks {
+		// If the event is not synced past, then we do not need to check
+		if event.ActivationHeight <= top {
+			version, err := p.FetchSyncedVersion(tx, event.ActivationHeight)
+			if err != nil {
+				return err
+			}
+			if version < event.MinimumVersion {
+				return fmt.Errorf("a hardfork occurred at height %d. This node was not updated prior to the hardfork, and synced these blocks with the incorrect version number. The found sync version was %d, and it required %d. The only way to fix this error is to ensure your node is updated, delete your database, and resync", event.ActivationHeight, version, event.MinimumVersion)
+			}
+		}
+	}
+
+	return nil
+}

--- a/node/pegnet/admin.go
+++ b/node/pegnet/admin.go
@@ -28,9 +28,6 @@ var (
 		// This is the most basic check. All versions are valid for 0
 		{0, -1}, // {0, -1}, means at height 0 any version >= -1 is sufficient
 
-		// Pegnet activation. When Pegnet starts on mainnet
-		{206422, 1},
-
 		// Future hardforks go here
 		// If the pegnet node syncs a hardfork height with any height less than
 		// the minimum version, the node will not start.

--- a/node/pegnet/admin_test.go
+++ b/node/pegnet/admin_test.go
@@ -32,14 +32,13 @@ func TestPegnet_CheckHardForks(t *testing.T) {
 		{ActivationHeight: 3, MinimumVersion: 3},
 		{ActivationHeight: 4, MinimumVersion: 4},
 		{ActivationHeight: 5, MinimumVersion: 5},
-		// Gap
 		{ActivationHeight: 9, MinimumVersion: 9},
-		// Gap
+		{ActivationHeight: 15, MinimumVersion: 15},
 		{ActivationHeight: 20, MinimumVersion: 20},
-		// Gap
 		{ActivationHeight: 1000, MinimumVersion: 1000},
 	}
 
+	// Height 0-10
 	t.Run("test all versions updated", func(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			pegnet.PegnetdSyncVersion = i
@@ -51,6 +50,17 @@ func TestPegnet_CheckHardForks(t *testing.T) {
 		}
 	})
 
+	// Height 15
+	t.Run("test version high above", func(t *testing.T) {
+		pegnet.PegnetdSyncVersion = 500
+		_ = p.MarkHeightSynced(p.DB, uint32(15))
+
+		if err := p.CheckHardForks(p.DB); err != nil {
+			t.Errorf("correct db error: %v", err)
+		}
+	})
+
+	// Height 20
 	t.Run("test version 1 behind", func(t *testing.T) {
 		pegnet.PegnetdSyncVersion = 19
 		_ = p.MarkHeightSynced(p.DB, uint32(20))

--- a/node/pegnet/admin_test.go
+++ b/node/pegnet/admin_test.go
@@ -1,0 +1,62 @@
+package pegnet_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/pegnet/pegnetd/node/pegnet"
+)
+
+func TestPegnet_CheckHardForks(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Error(err)
+	}
+
+	p := new(pegnet.Pegnet)
+	p.DB = db
+	if err := p.CreateTableSyncVersion(); err != nil {
+		t.Error(err)
+	}
+
+	t.Run("test blank db", func(t *testing.T) {
+		if err := p.CheckHardForks(p.DB); err != nil {
+			t.Errorf("blank db error: %v", err)
+		}
+	})
+
+	pegnet.Hardforks = []pegnet.ForkEvent{
+		{ActivationHeight: 0, MinimumVersion: 0},
+		{ActivationHeight: 1, MinimumVersion: 1},
+		{ActivationHeight: 2, MinimumVersion: 2},
+		{ActivationHeight: 3, MinimumVersion: 3},
+		{ActivationHeight: 4, MinimumVersion: 4},
+		{ActivationHeight: 5, MinimumVersion: 5},
+		// Gap
+		{ActivationHeight: 9, MinimumVersion: 9},
+		// Gap
+		{ActivationHeight: 20, MinimumVersion: 20},
+		// Gap
+		{ActivationHeight: 1000, MinimumVersion: 1000},
+	}
+
+	t.Run("test all versions updated", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			pegnet.PegnetdSyncVersion = i
+			_ = p.MarkHeightSynced(p.DB, uint32(i))
+		}
+
+		if err := p.CheckHardForks(p.DB); err != nil {
+			t.Errorf("correct db error: %v", err)
+		}
+	})
+
+	t.Run("test version 1 behind", func(t *testing.T) {
+		pegnet.PegnetdSyncVersion = 19
+		_ = p.MarkHeightSynced(p.DB, uint32(20))
+
+		if err := p.CheckHardForks(p.DB); err == nil {
+			t.Errorf("expected error, found none")
+		}
+	})
+}

--- a/node/pegnet/metadata.go
+++ b/node/pegnet/metadata.go
@@ -24,6 +24,13 @@ func (p *Pegnet) InsertSynced(tx *sql.Tx, bs *BlockSync) error {
 		return err
 	}
 
+	// Since this is called for every height, we also can mark the height
+	// synced for version checking
+	err = p.MarkHeightSynced(tx, bs.Synced)
+	if err != nil {
+		return err
+	}
+
 	_, err = tx.Exec("REPLACE INTO pn_metadata (name, value) VALUES ($1, $2)", "synced", data)
 	if err != nil {
 		return err

--- a/node/pegnet/pegnet.go
+++ b/node/pegnet/pegnet.go
@@ -79,6 +79,7 @@ func (p *Pegnet) createTables() error {
 		createTableTxHistoryBatch,
 		createTableTxHistoryTx,
 		createTableTxHistoryLookup,
+		createTableSyncVersion,
 	} {
 		if _, err := p.DB.Exec(sql); err != nil {
 			return err


### PR DESCRIPTION
If a pegnetd node is not updated late for a hard fork, meaning
a hard fork activates at height X, and the node is updated at X+1,
this code will prevent that node from launching. This is because
the node's state is incorrect. Preventing the node from launching
protects the user from an invalid state. A flag option is provided to
ignore this check if needed.