### PR TITLE
Limit conversions

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -17,9 +17,9 @@ import (
 	"github.com/pegnet/pegnetd/node"
 	"github.com/pegnet/pegnetd/node/pegnet"
 	"github.com/pegnet/pegnetd/srv"
+	"github.com/shopspring/decimal"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/shopspring/decimal"
 )
 
 func init() {
@@ -296,11 +296,11 @@ var limitConv = &cobra.Command{
 	Use:     "limitcvt <ECAddress> <FA-SOURCE> <SRC-ASSET> <AMOUNT> <DEST-ASSET> <LIMIT>",
 	Aliases: []string{"lcvt", "limitconversion", "limitconvert"},
 	Short:   "Builds and submits a pegnet conversion when the specified limit is reached",
-	Long: 	"Only converts an asset when the limit condition is met. By default this condition is " +
-	"when the source asset is below the provided limit.\nTo convert when the destination asset reaches the limit instead use the '--dest' flag.\n" +
-	"To convert when the selected asset is above the limit threshold rather than below, use the '--above' flag.\n" + 
-	"to test without actually going through with the conversion use the '--dryrun' flag, it will print out when the condition is met" +
-	"", 
+	Long: "Only converts an asset when the limit condition is met. By default this condition is " +
+		"when the source asset is below the provided limit.\nTo convert when the destination asset reaches the limit instead use the '--dest' flag.\n" +
+		"To convert when the selected asset is above the limit threshold rather than below, use the '--above' flag.\n" +
+		"to test without actually going through with the conversion use the '--dryrun' flag, it will print out when the condition is met" +
+		"",
 	Example: "pegnetd limitcvt EC3eX8VxGH64Xv3NFd9g4Y7PxSMnH3EGz5jQQrrQS8VZGnv4JY2K FA32xV6SoPBSbAZAVyuiHWwyoMYhnSyMmAHZfK29H8dx7bJXFLja" +
 		" pXBT 1 pUSD 9000.00 --above",
 	PersistentPreRun: always,

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -295,11 +295,11 @@ var conv = &cobra.Command{
 var limitConv = &cobra.Command{
 	Use:     "limitcvt <ECAddress> <FA-SOURCE> <SRC-ASSET> <AMOUNT> <DEST-ASSET> <LIMIT>",
 	Aliases: []string{"lcvt", "limitconversion", "limitconvert"},
-	Short:   "Builds and submits a pegnet conversion when the source asset reaches the specified limit",
+	Short:   "Builds and submits a pegnet conversion when the specified limit is reached",
 	Long: 	"Only converts an asset when the limit condition is met. By default this condition is " +
-	"when the source asset is below the provided limit.\nTo convert when the destination asset reaches the limit instead of the source use the '--dest' flag.\n" +
+	"when the source asset is below the provided limit.\nTo convert when the destination asset reaches the limit instead use the '--dest' flag.\n" +
 	"To convert when the selected asset is above the limit threshold rather than below, use the '--above' flag.\n" + 
-	"to test the logic without actually going through with the conversion use the '--dryrun' flag" +
+	"to test without actually going through with the conversion use the '--dryrun' flag, it will print out when the condition is met" +
 	"", 
 	Example: "pegnetd limitcvt EC3eX8VxGH64Xv3NFd9g4Y7PxSMnH3EGz5jQQrrQS8VZGnv4JY2K FA32xV6SoPBSbAZAVyuiHWwyoMYhnSyMmAHZfK29H8dx7bJXFLja" +
 		" pXBT 1 pUSD 9000.00 --above",

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -353,8 +353,9 @@ var limitConv = &cobra.Command{
 				} else {
 					waiting = limit.LessThan(newRate)
 				}
+			} else {
+				time.Sleep(300 * time.Second)
 			}
-			time.Sleep(300 * time.Second)
 		}
 
 		if dryrun {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/pegnet/pegnet v0.3.0
 	github.com/rs/cors v1.7.0
+	github.com/shopspring/decimal v0.0.0-20200105231215-408a2507e114
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -239,6 +239,8 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/shopspring/decimal v0.0.0-20200105231215-408a2507e114 h1:Pm6R878vxWWWR+Sa3ppsLce/Zq+JNTs6aVvRu13jv9A=
+github.com/shopspring/decimal v0.0.0-20200105231215-408a2507e114/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=


### PR DESCRIPTION
Adds a conversion command that only triggers when certain conditions are met. By default this is when the source is below the limit amount. Optional flags include using the destination asset as the trigger instead and/or being above a certain amount. 
Additionally adds a dryrun flag which will go through the functions logic but will exit before completing the conversion.