### PR TITLE
Update factom api dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 )
 
-replace github.com/Factom-Asset-Tokens/factom => github.com/Emyrk/factom v0.0.0-20191212151433-bd8a5cb70c70
+replace github.com/Factom-Asset-Tokens/factom => github.com/Emyrk/factom v0.0.0-20200113153851-17d98c31e1bd
 
 replace crawshaw.io/sqlite => github.com/AdamSLevy/sqlite v0.1.3-0.20191014215059-b98bb18889de
 

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Emyrk/factom v0.0.0-20191212151433-bd8a5cb70c70 h1:YnlSVyv/S+yiaX5yA+cHLYt4Ohq1WYr1MGbtVOhJTcg=
-github.com/Emyrk/factom v0.0.0-20191212151433-bd8a5cb70c70/go.mod h1:cWJszeYLd+RDyiNpHGfWPyoT/VoX71nxPTRvK/RVYRk=
+github.com/Emyrk/factom v0.0.0-20200113153851-17d98c31e1bd h1:juqMyTR16hT3tPfDCk++mD9UdEtiIHglQ7aSpmsbskk=
+github.com/Emyrk/factom v0.0.0-20200113153851-17d98c31e1bd/go.mod h1:cWJszeYLd+RDyiNpHGfWPyoT/VoX71nxPTRvK/RVYRk=
 github.com/Factom-Asset-Tokens/base58 v0.0.0-20181227014902-61655c4dd885 h1:rfy2fwMrOZPqQgjsH7VCreGMSPzcvqQrfjeSs8nf+sY=
 github.com/Factom-Asset-Tokens/base58 v0.0.0-20181227014902-61655c4dd885/go.mod h1:RVXsRSp6VzXw5l1uiGazuf3qo23Qk0h1HzMcQk+X4LE=
 github.com/FactomProject/FactomCode v0.3.5 h1:WKa5H9cg7V/zrteqBiEOdnpIxzRggOZMLlS3XLeBW2w=


### PR DESCRIPTION
Pulls in the latest change to emyrk/factom@rcd_full, containing the timestamp signing fix: https://github.com/Emyrk/factom/pull/2