### PR TITLE
Add `get-graded` API method

### DIFF
--- a/node/pegnet/winners.go
+++ b/node/pegnet/winners.go
@@ -3,6 +3,7 @@ package pegnet
 import (
 	"context"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"strings"
 )
@@ -91,6 +92,65 @@ func (p *Pegnet) SelectMinerDominance(ctx context.Context, start, stop int) (Min
 			m.GradedPercentage = float64(m.TotalGraded) / float64(result.TotalGraded)
 			result.Miners[add] = m
 		}
+	}
+
+	return result, nil
+}
+
+type GradedResult struct {
+	Height int32    `json:"height"`
+	Graded []Graded `json:"graded"`
+}
+
+type Graded struct {
+	EntryHash  string `json:"entryhash"`
+	Payout     uint64 `json:"payout"`
+	Nonce      string `json:"nonce"`
+	Difficulty string `json:"difficulty"`
+	Position   uint8  `json:"position"`
+	MinerID    string `json:"minerid"`
+	Address    string `json:"address"`
+}
+
+func (p *Pegnet) SelectGraded(ctx context.Context, height int32) (GradedResult, error) {
+	result := GradedResult{Height: height, Graded: make([]Graded, 0)}
+
+	stmtString := `
+	SELECT entryhash, payout, nonce, difficulty, position, minerid, address 
+	FROM pn_winners 
+	WHERE height = ?
+	`
+
+	rows, err := p.DB.QueryContext(ctx, stmtString, result.Height)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return result, nil
+		}
+		return result, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var entryhash, nonce, difficulty sql.RawBytes
+		var address, minerid string
+		var payout uint64
+		var position uint8
+		err := rows.Scan(&entryhash, &payout, &nonce, &difficulty, &position, &minerid, &address)
+		if err != nil {
+			return result, err
+		}
+
+		// Add address results
+		result.Graded = append(result.Graded, Graded{
+			EntryHash:  hex.EncodeToString(entryhash),
+			Payout:     payout,
+			Nonce:      hex.EncodeToString(nonce),
+			Difficulty: hex.EncodeToString(difficulty),
+			Position:   position,
+			MinerID:    minerid,
+			Address:    address,
+		})
+
 	}
 
 	return result, nil

--- a/node/pegnet/winners.go
+++ b/node/pegnet/winners.go
@@ -3,6 +3,7 @@ package pegnet
 import (
 	"context"
 	"database/sql"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -106,7 +107,7 @@ type Graded struct {
 	EntryHash  string `json:"entryhash"`
 	Payout     uint64 `json:"payout"`
 	Nonce      string `json:"nonce"`
-	Difficulty string `json:"difficulty"`
+	Difficulty uint64 `json:"difficulty"`
 	Position   uint8  `json:"position"`
 	MinerID    string `json:"minerid"`
 	Address    string `json:"address"`
@@ -145,7 +146,7 @@ func (p *Pegnet) SelectGraded(ctx context.Context, height int32) (GradedResult, 
 			EntryHash:  hex.EncodeToString(entryhash),
 			Payout:     payout,
 			Nonce:      hex.EncodeToString(nonce),
-			Difficulty: hex.EncodeToString(difficulty),
+			Difficulty: binary.BigEndian.Uint64(difficulty),
 			Position:   position,
 			MinerID:    minerid,
 			Address:    address,

--- a/srv/methods.go
+++ b/srv/methods.go
@@ -52,6 +52,7 @@ func (s *APIServer) jrpcMethods() jrpc.MethodMap {
 		"get-transaction":        s.getTransactions(true),
 		"get-pegnet-balances":    s.getPegnetBalances,
 		"get-pegnet-issuance":    s.getPegnetIssuance,
+		"get-graded":             s.getGraded,
 		"send-transaction":       s.sendTransaction,
 
 		"get-sync-status": s.getSyncStatus,
@@ -545,6 +546,20 @@ func (s *APIServer) getSyncStatus(_ context.Context, data json.RawMessage) inter
 		return ResultGetSyncStatus{Sync: s.Node.GetCurrentSync(), Current: -1}
 	}
 	return ResultGetSyncStatus{Sync: s.Node.GetCurrentSync(), Current: int32(heights.DirectoryBlock)}
+}
+
+func (s *APIServer) getGraded(ctx context.Context, data json.RawMessage) interface{} {
+	params := ParamsGetGraded{}
+	_, _, err := validate(data, &params)
+	if err != nil {
+		return err
+	}
+
+	result, err := s.Node.Pegnet.SelectGraded(ctx, params.Height)
+	if err != nil {
+		return err
+	}
+	return result
 }
 
 // TODO: Re-eval this function. The chain data that is supplied needs to be reimplemented

--- a/srv/methods.go
+++ b/srv/methods.go
@@ -511,7 +511,6 @@ func (s *APIServer) sendTransaction(_ context.Context, data json.RawMessage) int
 		TxID    *factom.Bytes32 `json:"txid,omitempty"`
 		Hash    *factom.Bytes32 `json:"entryhash"`
 	}{ChainID: entry.ChainID, TxID: &txID, Hash: entry.Hash}
-	return nil
 }
 
 //func attemptApplyFAT2TxBatch(chain *engine.Chain, e factom.Entry) (txErr, err error) {

--- a/srv/methods.go
+++ b/srv/methods.go
@@ -555,6 +555,14 @@ func (s *APIServer) getGraded(ctx context.Context, data json.RawMessage) interfa
 		return err
 	}
 
+	if params.Height == 0 {
+		synced, err := s.Node.Pegnet.SelectSynced(ctx, s.Node.Pegnet.DB)
+		if err != nil {
+			return err
+		}
+		params.Height = int32(synced.Synced)
+	}
+
 	result, err := s.Node.Pegnet.SelectGraded(ctx, params.Height)
 	if err != nil {
 		return err

--- a/srv/params.go
+++ b/srv/params.go
@@ -280,6 +280,9 @@ type ParamsGetGraded struct {
 
 func (p ParamsGetGraded) HasIncludePending() bool { return false }
 func (p ParamsGetGraded) IsValid() error {
+	if p.Height < 0 {
+		return jrpc.ErrorInvalidParams("height must be >= 0")
+	}
 	return nil
 }
 func (p ParamsGetGraded) ValidChainID() *factom.Bytes32 {

--- a/srv/params.go
+++ b/srv/params.go
@@ -274,6 +274,18 @@ func (p ParamsGetPegnetBalances) ValidChainID() *factom.Bytes32 {
 	return nil
 }
 
+type ParamsGetGraded struct {
+	Height int32 `json:"height,omitempty"`
+}
+
+func (p ParamsGetGraded) HasIncludePending() bool { return false }
+func (p ParamsGetGraded) IsValid() error {
+	return nil
+}
+func (p ParamsGetGraded) ValidChainID() *factom.Bytes32 {
+	return nil
+}
+
 type ParamsSendTransaction struct {
 	ParamsToken
 	ExtIDs  []factom.Bytes `json:"extids,omitempty"`


### PR DESCRIPTION
PR adds a new API method `get-graded`. Method accepts a single height as a parameter and returns a selection of fields from all graded OPRs for that height from the DB. 