### PR TITLE
Add v5 pAssets for Pegnet 2.0

### DIFF
--- a/cmd/args.go
+++ b/cmd/args.go
@@ -51,7 +51,7 @@ func CustomArgOrderValidationBuilder(strict bool, valids ...func(cmd *cobra.Comm
 
 // ArgValidatorAssetAndAll checks for valid asset or 'all'
 func ArgValidatorAssetOrP(cmd *cobra.Command, arg string) error {
-	list := opr.V4Assets
+	list := opr.V5Assets
 	for _, an := range list {
 		if strings.ToLower(arg) == strings.ToLower(an) {
 			return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -153,7 +153,7 @@ func always(cmd *cobra.Command, args []string) {
 
 	if testingact, _ := cmd.Flags().GetInt32("testingact"); testingact >= 0 {
 		fat2.Fat2RCDEActivation = uint32(testingact)
-		node.V4OPRUpdate = uint32(testingact)
+		node.V5OPRUpdate = uint32(testingact)
 		// Also updaet hardfork
 		pegnet.Hardforks[1].ActivationHeight = uint32(testingact)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -153,7 +153,7 @@ func always(cmd *cobra.Command, args []string) {
 
 	if testingact, _ := cmd.Flags().GetInt32("testingact"); testingact >= 0 {
 		fat2.Fat2RCDEActivation = uint32(testingact)
-		node.V5OPRUpdate = uint32(testingact)
+		node.V20HeightActivation = uint32(testingact)
 		// Also updaet hardfork
 		pegnet.Hardforks[1].ActivationHeight = uint32(testingact)
 	}

--- a/fat/fat2/pticker.go
+++ b/fat/fat2/pticker.go
@@ -64,6 +64,9 @@ const (
 	PTickerDOGE
 	PTickerVET
 	PTickerHT
+	PTickerARS
+	PTickerTWD
+	PTickerALGO
 	PTickerMax
 )
 
@@ -121,6 +124,9 @@ var validPTickerStrings = []string{
 	"pDOGE",
 	"pVET",
 	"pHT",
+	"pARS",
+	"pTWD",
+	"pALGO",
 }
 
 var validPTickers = func() map[string]PTicker {

--- a/fat/fat2/pticker.go
+++ b/fat/fat2/pticker.go
@@ -57,16 +57,24 @@ const (
 	// V5 Additions
 	PTickerHBAR
 	PTickerNEO
-	PTickerAED
 	PTickerCRO
 	PTickerETC
 	PTickerONT
 	PTickerDOGE
 	PTickerVET
 	PTickerHT
+	PTickerALGO
+	PTickerDGB
+	PTickerAED
 	PTickerARS
 	PTickerTWD
-	PTickerALGO
+	PTickerRWF
+	PTickerKES
+	PTickerUGX
+	PTickerTZS
+	PTickerBIF
+	PTickerETB
+	PTickerNGN
 	PTickerMax
 )
 
@@ -117,16 +125,24 @@ var validPTickerStrings = []string{
 	// V5 Additions
 	"pHBAR",
 	"pNEO",
-	"pAED",
 	"pCRO",
 	"pETC",
 	"pONT",
 	"pDOGE",
 	"pVET",
 	"pHT",
+	"pALGO",
+	"pDGB",
+	"pAED",
 	"pARS",
 	"pTWD",
-	"pALGO",
+	"pRWF",
+	"pKES",
+	"pUGX",
+	"pTZS",
+	"pBIF",
+	"pETB",
+	"pNGN",
 }
 
 var validPTickers = func() map[string]PTicker {

--- a/fat/fat2/pticker.go
+++ b/fat/fat2/pticker.go
@@ -54,6 +54,16 @@ const (
 	PTickerATOM
 	PTickerBAT
 	PTickerXTZ
+	// V5 Additions
+	PTickerHBAR
+	PTickerNEO
+	PTickerAED
+	PTickerCRO
+	PTickerETC
+	PTickerONT
+	PTickerDOGE
+	PTickerVET
+	PTickerHT
 	PTickerMax
 )
 
@@ -101,6 +111,16 @@ var validPTickerStrings = []string{
 	"pATOM",
 	"pBAT",
 	"pXTZ",
+	// V5 Additions
+	"pHBAR",
+	"pNEO",
+	"pAED",
+	"pCRO",
+	"pETC",
+	"pONT",
+	"pDOGE",
+	"pVET",
+	"pHT",
 }
 
 var validPTickers = func() map[string]PTicker {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AdamSLevy/jsonrpc2/v13 v13.0.1
 	github.com/Factom-Asset-Tokens/factom v0.0.0-20191114224337-71de98ff5b3e
 	github.com/mattn/go-sqlite3 v1.11.0
-	github.com/pegnet/pegnet v0.4.1-0.20200203165724-3fc45a9a417a
+	github.com/pegnet/pegnet v0.5.1-0.20200723222201-c2cae6127a81
 	github.com/rs/cors v1.7.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,8 @@ github.com/pegnet/pegnet v0.1.0-rc4.0.20200203154732-7279aa20fb8e h1:3HVpD9thq/V
 github.com/pegnet/pegnet v0.1.0-rc4.0.20200203154732-7279aa20fb8e/go.mod h1:Fy8Qohe9zIuqO9Q/ZOLUNpP2kuiFqxjevzaS3IL62+E=
 github.com/pegnet/pegnet v0.4.1-0.20200203165724-3fc45a9a417a h1:JWKI8cKFamD9yYr4Gq7EMzFBxjCQM/NI5K7V0wKse4U=
 github.com/pegnet/pegnet v0.4.1-0.20200203165724-3fc45a9a417a/go.mod h1:Fy8Qohe9zIuqO9Q/ZOLUNpP2kuiFqxjevzaS3IL62+E=
+github.com/pegnet/pegnet v0.5.1-0.20200723222201-c2cae6127a81 h1:CPsIntmwrXaKJSXnxT3vP3iK3KQ9ZVLOHD7e6HXICOo=
+github.com/pegnet/pegnet v0.5.1-0.20200723222201-c2cae6127a81/go.mod h1:Fy8Qohe9zIuqO9Q/ZOLUNpP2kuiFqxjevzaS3IL62+E=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=

--- a/node/node.go
+++ b/node/node.go
@@ -50,6 +50,10 @@ var (
 	// V4OPRUpdate indicates the activation of additional currencies and ecdsa keys.
 	// Estimated to be  Feb 12, 2020, 18:00 UTC
 	V4OPRUpdate uint32 = 231620
+
+	// V5OPRUpdate indicates the activation of additional currencies and ecdsa keys.
+	// Estimated to be  May 11, 2020, 18:00 UTC
+	V5OPRUpdate uint32 = 244970
 )
 
 func SetAllActivations(act uint32) {
@@ -62,6 +66,7 @@ func SetAllActivations(act uint32) {
 	PEGFreeFloatingPriceActivation = act
 	fat2.Fat2RCDEActivation = act
 	V4OPRUpdate = act
+	V5OPRUpdate = act
 }
 
 type Pegnetd struct {

--- a/node/node.go
+++ b/node/node.go
@@ -52,8 +52,8 @@ var (
 	V4OPRUpdate uint32 = 231620
 
 	// V5OPRUpdate indicates the activation of additional currencies and ecdsa keys.
-	// Estimated to be  May 11, 2020, 18:00 UTC
-	V5OPRUpdate uint32 = 244970
+	// TODO: TBD
+	V5OPRUpdate uint32 = 999999
 )
 
 func SetAllActivations(act uint32) {

--- a/node/opr.go
+++ b/node/opr.go
@@ -30,7 +30,7 @@ func (d *Pegnetd) Grade(ctx context.Context, block *factom.EBlock) (grader.Grade
 	if block.Height >= V4OPRUpdate {
 		ver = 4
 	}
-	if block.Height >= V5OPRUpdate {
+	if block.Height >= V20HeightActivation {
 		ver = 5
 	}
 

--- a/node/opr.go
+++ b/node/opr.go
@@ -30,6 +30,9 @@ func (d *Pegnetd) Grade(ctx context.Context, block *factom.EBlock) (grader.Grade
 	if block.Height >= V4OPRUpdate {
 		ver = 4
 	}
+	if block.Height >= V5OPRUpdate {
+		ver = 5
+	}
 
 	var prevWinners []string = nil
 	prev, err := d.Pegnet.SelectPreviousWinners(ctx, block.Height)

--- a/node/pegnet/addresses.go
+++ b/node/pegnet/addresses.go
@@ -115,7 +115,13 @@ const createTableAddresses = `CREATE TABLE IF NOT EXISTS "pn_addresses" (
         "pvet_balance"  INTEGER NOT NULL DEFAULT 0
                         CONSTRAINT "insufficient balance" CHECK ("pvet_balance" >= 0),
         "pht_balance"  INTEGER NOT NULL DEFAULT 0
-                        CONSTRAINT "insufficient balance" CHECK ("pht_balance" >= 0)		
+                        CONSTRAINT "insufficient balance" CHECK ("pht_balance" >= 0),
+        "pars_balance"  INTEGER NOT NULL DEFAULT 0
+                        CONSTRAINT "insufficient balance" CHECK ("pars_balance" >= 0),
+        "ptwd_balance"  INTEGER NOT NULL DEFAULT 0
+                        CONSTRAINT "insufficient balance" CHECK ("ptwd_balance" >= 0),
+        "palgo_balance"  INTEGER NOT NULL DEFAULT 0
+                        CONSTRAINT "insufficient balance" CHECK ("palgo_balance" >= 0),		
 );
 CREATE INDEX IF NOT EXISTS "idx_address_balances_address_id" ON "pn_addresses"("address");
 `
@@ -215,6 +221,15 @@ ALTER TABLE pn_addresses
 ALTER TABLE pn_addresses
         ADD "pht_balance"  INTEGER NOT NULL DEFAULT 0
             CONSTRAINT "insufficient balance" CHECK ("pht_balance" >= 0);
+ALTER TABLE pn_addresses
+        ADD "pars_balance"  INTEGER NOT NULL DEFAULT 0
+            CONSTRAINT "insufficient balance" CHECK ("pars_balance" >= 0);
+ALTER TABLE pn_addresses
+        ADD "ptwd_balance"  INTEGER NOT NULL DEFAULT 0
+            CONSTRAINT "insufficient balance" CHECK ("ptwd_balance" >= 0);
+ALTER TABLE pn_addresses
+        ADD "palgo_balance"  INTEGER NOT NULL DEFAULT 0
+            CONSTRAINT "insufficient balance" CHECK ("palgo_balance" >= 0);
 `
 
 func (p *Pegnet) v5MigrationNeeded() (migrate bool, err error) {
@@ -474,6 +489,9 @@ func (Pegnet) selectBalances(q QueryAble, adr *factom.FAAddress) (map[fat2.PTick
 		&balances[fat2.PTickerDOGE],
 		&balances[fat2.PTickerVET],
 		&balances[fat2.PTickerHT],
+		&balances[fat2.PTickerARS],
+		&balances[fat2.PTickerTWD],
+		&balances[fat2.PTickerALGO],
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -564,6 +582,9 @@ func (p *Pegnet) SelectAllBalances() ([]BalancesPair, error) {
 			&bp.Balances[fat2.PTickerDOGE],
 			&bp.Balances[fat2.PTickerVET],
 			&bp.Balances[fat2.PTickerHT],
+			&bp.Balances[fat2.PTickerARS],
+			&bp.Balances[fat2.PTickerTWD],
+			&bp.Balances[fat2.PTickerALGO],
 		)
 		if err != nil {
 			return nil, err
@@ -647,6 +668,9 @@ func (p *Pegnet) SelectIssuances() (map[fat2.PTicker]uint64, error) {
 		&issuances[fat2.PTickerDOGE],
 		&issuances[fat2.PTickerVET],
 		&issuances[fat2.PTickerHT],
+		&issuances[fat2.PTickerARS],
+		&issuances[fat2.PTickerTWD],
+		&issuances[fat2.PTickerALGO],
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/node/pegnet/addresses.go
+++ b/node/pegnet/addresses.go
@@ -102,8 +102,6 @@ const createTableAddresses = `CREATE TABLE IF NOT EXISTS "pn_addresses" (
                         CONSTRAINT "insufficient balance" CHECK ("phbar_balance" >= 0),
         "pneo_balance"  INTEGER NOT NULL DEFAULT 0
                         CONSTRAINT "insufficient balance" CHECK ("pneo_balance" >= 0),
-        "paed_balance"  INTEGER NOT NULL DEFAULT 0
-                        CONSTRAINT "insufficient balance" CHECK ("paed_balance" >= 0),
         "pcro_balance"  INTEGER NOT NULL DEFAULT 0
                         CONSTRAINT "insufficient balance" CHECK ("pcro_balance" >= 0),
         "petc_balance"  INTEGER NOT NULL DEFAULT 0
@@ -116,12 +114,30 @@ const createTableAddresses = `CREATE TABLE IF NOT EXISTS "pn_addresses" (
                         CONSTRAINT "insufficient balance" CHECK ("pvet_balance" >= 0),
         "pht_balance"  INTEGER NOT NULL DEFAULT 0
                         CONSTRAINT "insufficient balance" CHECK ("pht_balance" >= 0),
+        "palgo_balance"  INTEGER NOT NULL DEFAULT 0
+                        CONSTRAINT "insufficient balance" CHECK ("palgo_balance" >= 0),
+        "pdgb_balance"  INTEGER NOT NULL DEFAULT 0
+                        CONSTRAINT "insufficient balance" CHECK ("pdgb_balance" >= 0),
+        "paed_balance"  INTEGER NOT NULL DEFAULT 0
+                        CONSTRAINT "insufficient balance" CHECK ("paed_balance" >= 0),
         "pars_balance"  INTEGER NOT NULL DEFAULT 0
                         CONSTRAINT "insufficient balance" CHECK ("pars_balance" >= 0),
         "ptwd_balance"  INTEGER NOT NULL DEFAULT 0
                         CONSTRAINT "insufficient balance" CHECK ("ptwd_balance" >= 0),
-        "palgo_balance"  INTEGER NOT NULL DEFAULT 0
-                        CONSTRAINT "insufficient balance" CHECK ("palgo_balance" >= 0),		
+        "prwf_balance"  INTEGER NOT NULL DEFAULT 0
+                        CONSTRAINT "insufficient balance" CHECK ("prwf_balance" >= 0),
+        "pkes_balance"  INTEGER NOT NULL DEFAULT 0
+                        CONSTRAINT "insufficient balance" CHECK ("pkes_balance" >= 0),
+        "pugx_balance"  INTEGER NOT NULL DEFAULT 0
+                        CONSTRAINT "insufficient balance" CHECK ("pugx_balance" >= 0),
+        "ptzs_balance"  INTEGER NOT NULL DEFAULT 0
+                        CONSTRAINT "insufficient balance" CHECK ("ptzs_balance" >= 0),
+        "pbif_balance"  INTEGER NOT NULL DEFAULT 0
+                        CONSTRAINT "insufficient balance" CHECK ("pbif_balance" >= 0),
+        "petb_balance"  INTEGER NOT NULL DEFAULT 0
+                        CONSTRAINT "insufficient balance" CHECK ("petb_balance" >= 0),
+        "pngn_balance"  INTEGER NOT NULL DEFAULT 0
+                        CONSTRAINT "insufficient balance" CHECK ("pngn_balance" >= 0),		
 );
 CREATE INDEX IF NOT EXISTS "idx_address_balances_address_id" ON "pn_addresses"("address");
 `
@@ -201,9 +217,6 @@ ALTER TABLE pn_addresses
         ADD "pneo_balance"  INTEGER NOT NULL DEFAULT 0
             CONSTRAINT "insufficient balance" CHECK ("pneo_balance" >= 0);
 ALTER TABLE pn_addresses
-        ADD "paed_balance"  INTEGER NOT NULL DEFAULT 0
-            CONSTRAINT "insufficient balance" CHECK ("paed_balance" >= 0);
-ALTER TABLE pn_addresses
         ADD "pcro_balance"  INTEGER NOT NULL DEFAULT 0
             CONSTRAINT "insufficient balance" CHECK ("pcro_balance" >= 0);
 ALTER TABLE pn_addresses
@@ -222,14 +235,41 @@ ALTER TABLE pn_addresses
         ADD "pht_balance"  INTEGER NOT NULL DEFAULT 0
             CONSTRAINT "insufficient balance" CHECK ("pht_balance" >= 0);
 ALTER TABLE pn_addresses
+        ADD "palgo_balance"  INTEGER NOT NULL DEFAULT 0
+            CONSTRAINT "insufficient balance" CHECK ("palgo_balance" >= 0);
+ALTER TABLE pn_addresses
+        ADD "pdgb_balance"  INTEGER NOT NULL DEFAULT 0
+            CONSTRAINT "insufficient balance" CHECK ("pdgb_balance" >= 0);
+ALTER TABLE pn_addresses
+        ADD "paed_balance"  INTEGER NOT NULL DEFAULT 0
+            CONSTRAINT "insufficient balance" CHECK ("paed_balance" >= 0);
+ALTER TABLE pn_addresses
         ADD "pars_balance"  INTEGER NOT NULL DEFAULT 0
             CONSTRAINT "insufficient balance" CHECK ("pars_balance" >= 0);
 ALTER TABLE pn_addresses
         ADD "ptwd_balance"  INTEGER NOT NULL DEFAULT 0
             CONSTRAINT "insufficient balance" CHECK ("ptwd_balance" >= 0);
 ALTER TABLE pn_addresses
-        ADD "palgo_balance"  INTEGER NOT NULL DEFAULT 0
-            CONSTRAINT "insufficient balance" CHECK ("palgo_balance" >= 0);
+        ADD "prwf_balance"  INTEGER NOT NULL DEFAULT 0
+            CONSTRAINT "insufficient balance" CHECK ("prwf_balance" >= 0);
+ALTER TABLE pn_addresses
+        ADD "pkes_balance"  INTEGER NOT NULL DEFAULT 0
+            CONSTRAINT "insufficient balance" CHECK ("pkes_balance" >= 0);
+ALTER TABLE pn_addresses
+        ADD "pugx_balance"  INTEGER NOT NULL DEFAULT 0
+            CONSTRAINT "insufficient balance" CHECK ("pugx_balance" >= 0);
+ALTER TABLE pn_addresses
+        ADD "ptzs_balance"  INTEGER NOT NULL DEFAULT 0
+            CONSTRAINT "insufficient balance" CHECK ("ptzs_balance" >= 0);
+ALTER TABLE pn_addresses
+        ADD "pbif_balance"  INTEGER NOT NULL DEFAULT 0
+            CONSTRAINT "insufficient balance" CHECK ("pbif_balance" >= 0);
+ALTER TABLE pn_addresses
+        ADD "petb_balance"  INTEGER NOT NULL DEFAULT 0
+            CONSTRAINT "insufficient balance" CHECK ("petb_balance" >= 0);
+ALTER TABLE pn_addresses
+        ADD "pngn_balance"  INTEGER NOT NULL DEFAULT 0
+            CONSTRAINT "insufficient balance" CHECK ("pngn_balance" >= 0);
 `
 
 func (p *Pegnet) v5MigrationNeeded() (migrate bool, err error) {
@@ -482,16 +522,24 @@ func (Pegnet) selectBalances(q QueryAble, adr *factom.FAAddress) (map[fat2.PTick
 		// V5 Additions
 		&balances[fat2.PTickerHBAR],
 		&balances[fat2.PTickerNEO],
-		&balances[fat2.PTickerAED],
 		&balances[fat2.PTickerCRO],
 		&balances[fat2.PTickerETC],
 		&balances[fat2.PTickerONT],
 		&balances[fat2.PTickerDOGE],
 		&balances[fat2.PTickerVET],
 		&balances[fat2.PTickerHT],
+		&balances[fat2.PTickerALGO],
+		&balances[fat2.PTickerDGB],
+		&balances[fat2.PTickerAED],
 		&balances[fat2.PTickerARS],
 		&balances[fat2.PTickerTWD],
-		&balances[fat2.PTickerALGO],
+		&balances[fat2.PTickerRWF],
+		&balances[fat2.PTickerKES],
+		&balances[fat2.PTickerUGX],
+		&balances[fat2.PTickerTZS],
+		&balances[fat2.PTickerBIF],
+		&balances[fat2.PTickerETB],
+		&balances[fat2.PTickerNGN],
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -575,16 +623,24 @@ func (p *Pegnet) SelectAllBalances() ([]BalancesPair, error) {
 			// V5 Additions
 			&bp.Balances[fat2.PTickerHBAR],
 			&bp.Balances[fat2.PTickerNEO],
-			&bp.Balances[fat2.PTickerAED],
 			&bp.Balances[fat2.PTickerCRO],
 			&bp.Balances[fat2.PTickerETC],
 			&bp.Balances[fat2.PTickerONT],
 			&bp.Balances[fat2.PTickerDOGE],
 			&bp.Balances[fat2.PTickerVET],
 			&bp.Balances[fat2.PTickerHT],
+			&bp.Balances[fat2.PTickerALGO],
+			&bp.Balances[fat2.PTickerDGB],
+			&bp.Balances[fat2.PTickerAED],
 			&bp.Balances[fat2.PTickerARS],
 			&bp.Balances[fat2.PTickerTWD],
-			&bp.Balances[fat2.PTickerALGO],
+			&bp.Balances[fat2.PTickerRWF],
+			&bp.Balances[fat2.PTickerKES],
+			&bp.Balances[fat2.PTickerUGX],
+			&bp.Balances[fat2.PTickerTZS],
+			&bp.Balances[fat2.PTickerBIF],
+			&bp.Balances[fat2.PTickerETB],
+			&bp.Balances[fat2.PTickerNGN],
 		)
 		if err != nil {
 			return nil, err
@@ -661,16 +717,24 @@ func (p *Pegnet) SelectIssuances() (map[fat2.PTicker]uint64, error) {
 		// V5 Additions
 		&issuances[fat2.PTickerHBAR],
 		&issuances[fat2.PTickerNEO],
-		&issuances[fat2.PTickerAED],
 		&issuances[fat2.PTickerCRO],
 		&issuances[fat2.PTickerETC],
 		&issuances[fat2.PTickerONT],
 		&issuances[fat2.PTickerDOGE],
 		&issuances[fat2.PTickerVET],
 		&issuances[fat2.PTickerHT],
+		&issuances[fat2.PTickerALGO],
+		&issuances[fat2.PTickerDGB],
+		&issuances[fat2.PTickerAED],
 		&issuances[fat2.PTickerARS],
 		&issuances[fat2.PTickerTWD],
-		&issuances[fat2.PTickerALGO],
+		&issuances[fat2.PTickerRWF],
+		&issuances[fat2.PTickerKES],
+		&issuances[fat2.PTickerUGX],
+		&issuances[fat2.PTickerTZS],
+		&issuances[fat2.PTickerBIF],
+		&issuances[fat2.PTickerETB],
+		&issuances[fat2.PTickerNGN],
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/node/pegnet/addresses.go
+++ b/node/pegnet/addresses.go
@@ -137,7 +137,7 @@ const createTableAddresses = `CREATE TABLE IF NOT EXISTS "pn_addresses" (
         "petb_balance"  INTEGER NOT NULL DEFAULT 0
                         CONSTRAINT "insufficient balance" CHECK ("petb_balance" >= 0),
         "pngn_balance"  INTEGER NOT NULL DEFAULT 0
-                        CONSTRAINT "insufficient balance" CHECK ("pngn_balance" >= 0),		
+                        CONSTRAINT "insufficient balance" CHECK ("pngn_balance" >= 0)		
 );
 CREATE INDEX IF NOT EXISTS "idx_address_balances_address_id" ON "pn_addresses"("address");
 `

--- a/node/pegnet/admin.go
+++ b/node/pegnet/admin.go
@@ -38,8 +38,8 @@ var (
 		{ActivationHeight: 231620, MinimumVersion: 1},
 
 		// V5 OPR Update
-		// Estimated to be  May 11, 2020, 18:00 UTC
-		{ActivationHeight: 999999, MinimumVersion: 2},
+		// Estimated to be  July 29th 2020 16:40 UTC
+		{ActivationHeight: 255778, MinimumVersion: 2},
 	}
 )
 

--- a/node/pegnet/admin.go
+++ b/node/pegnet/admin.go
@@ -39,7 +39,7 @@ var (
 
 		// V5 OPR Update
 		// Estimated to be  May 11, 2020, 18:00 UTC
-		{ActivationHeight: 244970, MinimumVersion: 1},
+		{ActivationHeight: 244970, MinimumVersion: 2},
 	}
 )
 

--- a/node/pegnet/admin.go
+++ b/node/pegnet/admin.go
@@ -36,6 +36,10 @@ var (
 		// V4 OPR Update
 		// Estimated to be  Feb 12, 2020, 18:00 UTC
 		{ActivationHeight: 231620, MinimumVersion: 1},
+
+		// V5 OPR Update
+		// Estimated to be  May 11, 2020, 18:00 UTC
+		{ActivationHeight: 244970, MinimumVersion: 1},
 	}
 )
 

--- a/node/pegnet/admin.go
+++ b/node/pegnet/admin.go
@@ -16,7 +16,7 @@ var (
 	// detect if a pegnetd was updated late, and therefore has an invalid state.
 	//
 	// Each fork should increment this number by at least 1
-	PegnetdSyncVersion = 1
+	PegnetdSyncVersion = 2
 )
 
 type ForkEvent struct {
@@ -39,7 +39,7 @@ var (
 
 		// V5 OPR Update
 		// Estimated to be  May 11, 2020, 18:00 UTC
-		{ActivationHeight: 244970, MinimumVersion: 2},
+		{ActivationHeight: 999999, MinimumVersion: 2},
 	}
 )
 

--- a/node/pegnet/pegnet.go
+++ b/node/pegnet/pegnet.go
@@ -117,6 +117,20 @@ func (p *Pegnet) migrations() error {
 		}
 	}
 
+	v5Migrate, err := p.v5MigrationNeeded()
+	if err != nil {
+		return err
+	}
+	if v5Migrate {
+		log.Infof("Running v5 migrations")
+		for _, sql := range []string{
+			addressTableV5Migration,
+		} {
+			if _, err := p.DB.Exec(sql); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Add v5 pAssets for Pegnet 2.0
1. Add additional V5 crypto assets.
HBAR, NEO, CRO, ETC, ONT, DOGE, VET, HT, ALGO, DGB

2. Add additional V5 currency assets.
AED, ARS, TWD, RWF, KES, UGX, TZS, BIF, ETB, NGN
