### PR TITLE
Adds global burn address. Set to zero balances at burn address

### DIFF
--- a/node/burns.go
+++ b/node/burns.go
@@ -1,10 +1,21 @@
 package node
 
-import "encoding/hex"
+import (
+	"encoding/hex"
+
+	"github.com/Factom-Asset-Tokens/factom"
+)
 
 var (
 	// BurnAddress is the mainnet burn address
 	BurnAddress = "EC2BURNFCT2PEGNETooo1oooo1oooo1oooo1oooo1oooo19wthin"
+
+	// BurnAddress that can be used for all assets
+	GlobalBurnAddress = "FA2BURNBABYBURNoooooooooooooooooooooooooooooooDGvNXy"
+
+	// Global Burn Address as proper FAAddress
+	FAGlobalBurnAddress factom.FAAddress
+
 	// BurnRCD is the rcd representation of the burn address
 	BurnRCD = [32]byte{}
 )

--- a/node/node.go
+++ b/node/node.go
@@ -110,6 +110,18 @@ func NewPegnetd(ctx context.Context, conf *viper.Viper) (*Pegnetd, error) {
 		}
 	}
 
+	// init burn address
+	FAGlobalBurnAddress, err := factom.NewFAAddress(GlobalBurnAddress)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Info("error getting burn address")
+	}
+
+	log.WithFields(log.Fields{
+		"addr": FAGlobalBurnAddress,
+	}).Info("burn address loaded")
+
 	grader.InitLX()
 	return n, nil
 }

--- a/node/pegnet/pegnet.go
+++ b/node/pegnet/pegnet.go
@@ -66,7 +66,6 @@ func (p *Pegnet) Init() error {
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/node/pegnet/pegnet.go
+++ b/node/pegnet/pegnet.go
@@ -66,6 +66,7 @@ func (p *Pegnet) Init() error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/node/pegnet/txhistory.go
+++ b/node/pegnet/txhistory.go
@@ -452,7 +452,7 @@ func (p *Pegnet) InsertStakingCoinbase(tx *sql.Tx, txid string, height uint32, h
 }
 
 // Special construction to nullify burn address
-func (p *Pegnet) InsertZeroingCoinbase(tx *sql.Tx, txid string, addTxid string, height uint32, heightTimestamp time.Time, payout uint64, faAdd factom.FAAddress) error {
+func (p *Pegnet) InsertZeroingCoinbase(tx *sql.Tx, txid string, addTxid string, height uint32, heightTimestamp time.Time, payout uint64, asset string, faAdd factom.FAAddress) error {
 	txidBytes, err := hex.DecodeString(txid)
 	if err != nil {
 		return err
@@ -474,7 +474,7 @@ func (p *Pegnet) InsertZeroingCoinbase(tx *sql.Tx, txid string, addTxid string, 
 		return err
 	}
 
-	// Now we record each zeroing payout.
+	// Now we record balance zeroing .
 
 	// All addresses are stored as bytes in the sqlitedb
 	add := faAdd[:]
@@ -484,7 +484,7 @@ func (p *Pegnet) InsertZeroingCoinbase(tx *sql.Tx, txid string, addTxid string, 
 		return err
 	}
 
-	// Insert each payout as a coinbase.
+	// Decrease each balance as a coinbase.
 	// Insert the TX
 	coinbaseStatement, err := tx.Prepare(`INSERT INTO "pn_history_transaction"
 		            (entry_hash, tx_index, action_type, from_address, from_asset, from_amount, to_asset, to_amount, outputs) VALUES
@@ -493,7 +493,7 @@ func (p *Pegnet) InsertZeroingCoinbase(tx *sql.Tx, txid string, addTxid string, 
 		return err
 	}
 
-	_, err = coinbaseStatement.Exec(txidBytes, index, Coinbase, add, "", 0, "PEG", payout, "")
+	_, err = coinbaseStatement.Exec(txidBytes, index, Coinbase, add, "", 0, asset, -payout, "") // -payout means we substract value
 	if err != nil {
 		return err
 	}

--- a/node/pegnet/txhistory.go
+++ b/node/pegnet/txhistory.go
@@ -450,3 +450,63 @@ func (p *Pegnet) InsertStakingCoinbase(tx *sql.Tx, txid string, height uint32, h
 
 	return nil
 }
+
+// Special construction to nullify burn address
+func (p *Pegnet) InsertZeroingCoinbase(tx *sql.Tx, txid string, addTxid string, height uint32, heightTimestamp time.Time, payout uint64, faAdd factom.FAAddress) error {
+	txidBytes, err := hex.DecodeString(txid)
+	if err != nil {
+		return err
+	}
+
+	// 	First we need to record the batch. The batch is the entire set of transactions, where
+	// 	each tx is a stake payout.
+	stmt, err := tx.Prepare(`INSERT INTO "pn_history_txbatch"
+                (entry_hash, height, blockorder, timestamp, executed) VALUES
+                (?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+
+	// The Entryhash is the custom txid, it is not an actual entry on chain
+	// The executed height is the same height as the recorded.
+	_, err = stmt.Exec(txidBytes, height, 0, heightTimestamp.Unix(), height)
+	if err != nil {
+		return err
+	}
+
+	// Now we record each zeroing payout.
+
+	// All addresses are stored as bytes in the sqlitedb
+	add := faAdd[:]
+	// index for the address
+	index, _, err := SplitTxID(txid)
+	if err != nil {
+		return err
+	}
+
+	// Insert each payout as a coinbase.
+	// Insert the TX
+	coinbaseStatement, err := tx.Prepare(`INSERT INTO "pn_history_transaction"
+		            (entry_hash, tx_index, action_type, from_address, from_asset, from_amount, to_asset, to_amount, outputs) VALUES
+		            (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+
+	_, err = coinbaseStatement.Exec(txidBytes, index, Coinbase, add, "", 0, "PEG", payout, "")
+	if err != nil {
+		return err
+	}
+
+	// Insert into lookup table
+	lookup, err := tx.Prepare(insertLookupQuery)
+	if err != nil {
+		return err
+	}
+
+	if _, err = lookup.Exec(txidBytes, index, add); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Use `FA2BURNBABYBURNoooooooooooooooooooooooooooooooDGvNXy` as global burn address

1) One time operation to remove current funds in `NullifyBurnAddress` function which subtracts all values from burn address used to lock funds after attack
1.1) retrieve all balances for provided address
1.2) loop through issuance and subtract exact amount
1.3) should be executed before main sync logic because db will be locked later on

2) Makes `FA2BURNBAB...` global burn address. Adds functionality that doesn't add funds when they are transacted to the burn address