### PR TITLE
Tolerance Band

### DIFF
--- a/node/sync.go
+++ b/node/sync.go
@@ -1266,7 +1266,7 @@ func (d *Pegnetd) GetAssetRates(oprWinners []opr.AssetUint, sprWinners []opr.Ass
 			if oprWinners[i].Name == sprWinners[i].Name {
 				sprRate := sprWinners[i].Value
 				oprRate := oprWinners[i].Value
-				toleranceRate := 0.1 // 10% band
+				toleranceRate := 0.25 // 25% band
 				toleranceBandHigh := float64(sprRate) * (1 + toleranceRate)
 				toleranceBandLow := float64(sprRate) * (1 - toleranceRate)
 				if (float64(oprRate) >= toleranceBandLow) && (float64(oprRate) <= toleranceBandHigh) {


### PR DESCRIPTION
- Purpose:
Increase the tolerance band range from 10% to 25% considering market prices & possible use cases between data providers and stakers. 

- How does it work?
Stakers' Oracle data will set the upper and lower limitation by 25%, and Miners will set the real prices if their values are included in the SPR tolerance band range.