### PR TITLE
[PIP-19] Stop conversions INTO pAssets that have small marketcap

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -354,6 +354,16 @@ var conv = &cobra.Command{
 			os.Exit(1)
 		}
 
+		// Let's check the pXXX -> pSmallAssets
+		// pSmallAssets means the 16 pAssets which have got small market cap.
+		if (destAsset == "PEG" || destAsset == "pDCR" || destAsset == "pDGB" || destAsset == "pDOGE" || destAsset == "pHBAR" ||
+			destAsset == "pONT" || destAsset == "pRVN" || destAsset == "pBAT" || destAsset == "pALGO" || destAsset == "pBIF" ||
+			destAsset == "pETB" || destAsset == "pKES" || destAsset == "pNGN" || destAsset == "pRWF" || destAsset == "pTZS" ||
+			destAsset == "pUGX") && uint32(status.Current) >= node.OneWaySmallAssetsConversions {
+			cmd.PrintErrln(fmt.Sprintf("pXXX -> pSmallAssets conversions are not allowed since block height %d.", node.OneWaySmallAssetsConversions))
+			os.Exit(1)
+		}
+
 		// Build the transaction from the args
 		var trans fat2.Transaction
 		if err := setTransactionInput(&trans, cl, originalSource, srcAsset, amt); err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -62,6 +62,12 @@ var (
 	// SprSignatureActivation indicates the activation of SPR Signature.
 	// Estimated to be  Aug 28th 2020
 	SprSignatureActivation uint32 = 260118
+
+	// OneWaypAssetsConversions makes some pAssets a 1 way conversion.
+	// pDCR, pDGB, pDOGE, pHBAR, pONT, pRVN, pBAT, pALGO, pBIF, pETB, pKES, pNGN, pRWF, pTZS, pUGX
+	// These pAssets have got small marketcap, and these will be disabled for conversion.
+	// Estimated to be XXXXXXXX
+	OneWaySmallAssetsConversions uint32 = 999999
 )
 
 func SetAllActivations(act uint32) {
@@ -76,6 +82,7 @@ func SetAllActivations(act uint32) {
 	V4OPRUpdate = act
 	V20HeightActivation = act
 	V20DevRewardsHeightActivation = act
+	OneWaySmallAssetsConversions = act
 }
 
 type Pegnetd struct {

--- a/node/pegnet/errors.go
+++ b/node/pegnet/errors.go
@@ -8,10 +8,12 @@ var (
 
 	// -2 is an invalid tx. Usually by timestamps
 
-	PFCTOneWayError          = errors.New("pFCT conversions are one way only at this height, they cannot be a conversion destination")
-	PFCTOneWayErrorInt int64 = -3
-	ZeroRatesError           = errors.New("an asset in the conversion has a rate of 0, and not allowed to be used for conversions")
-	ZeroRatesErrorInt  int64 = -4
+	PFCTOneWayError            = errors.New("pFCT conversions are one way only at this height, they cannot be a conversion destination")
+	PFCTOneWayErrorInt   int64 = -3
+	ZeroRatesError             = errors.New("an asset in the conversion has a rate of 0, and not allowed to be used for conversions")
+	ZeroRatesErrorInt    int64 = -4
+	PSMALLOneWayError          = errors.New("small marketcap assets conversions are one way only at this height, they cannot be a conversion destination")
+	PSMALLOneWayErrorInt int64 = -5
 )
 
 // IsRejectedTx takes an error, and returns the integer form of that error
@@ -26,6 +28,9 @@ func IsRejectedTx(err error) (int64, error) {
 	}
 	if err == PFCTOneWayError {
 		return PFCTOneWayErrorInt, nil
+	}
+	if err == PSMALLOneWayError {
+		return PSMALLOneWayErrorInt, nil
 	}
 	if err == ZeroRatesError {
 		return ZeroRatesErrorInt, nil

--- a/node/sync.go
+++ b/node/sync.go
@@ -912,6 +912,18 @@ func (d *Pegnetd) applyTransactionBatch(sqlTx *sql.Tx, txBatch *fat2.Transaction
 				return pegnet.PFCTOneWayError
 			}
 
+			// pXXX -> pDCR conversions are disabled at the activation height.
+			// FYI, PEG one way conversion was disabled at V20HeightActivation already.
+			if currentHeight >= OneWaySmallAssetsConversions &&
+				(tx.Conversion == fat2.PTickerPEG || tx.Conversion == fat2.PTickerDCR || tx.Conversion == fat2.PTickerDGB ||
+					tx.Conversion == fat2.PTickerDOGE || tx.Conversion == fat2.PTickerHBAR || tx.Conversion == fat2.PTickerONT ||
+					tx.Conversion == fat2.PTickerRVN || tx.Conversion == fat2.PTickerBAT || tx.Conversion == fat2.PTickerALGO ||
+					tx.Conversion == fat2.PTickerBIF || tx.Conversion == fat2.PTickerETB || tx.Conversion == fat2.PTickerKES ||
+					tx.Conversion == fat2.PTickerNGN || tx.Conversion == fat2.PTickerRWF || tx.Conversion == fat2.PTickerTZS ||
+					tx.Conversion == fat2.PTickerUGX) {
+				return pegnet.PSMALLOneWayError
+			}
+
 			// TODO: For now any bogus amounts will be tossed. Someone can fake an overflow for example,
 			// 		and hold us up forever.
 			_, err := conversions.Convert(int64(tx.Input.Amount), rates[tx.Input.Type], rates[tx.Conversion])


### PR DESCRIPTION
- PegNet disable small market cap pAssets conversion and allow only one way conversion.

pDCR,  pDGB, pDOGE,  pHBAR, pONT, pRVN, pBAT, pALGO, pBIF, pETB, pKES, pNGN, pRWF, pTZS, pUGX
