### PR TITLE
Add TestNet mode with chainID initialization

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ import (
 
 func init() {
 	rootCmd.PersistentFlags().String("log", "info", "Change the logging level. Can choose from 'trace', 'debug', 'info', 'warn', 'error', or 'fatal'")
+	rootCmd.PersistentFlags().StringP("network", "", "", "The network for PegNetD")
 	rootCmd.PersistentFlags().StringP("server", "s", "http://localhost:8088/v2", "The url to the factomd endpoint without a trailing slash")
 	rootCmd.PersistentFlags().StringP("wallet", "w", "http://localhost:8089/v2", "The url to the factomd-wallet endpoint without a trailing slash")
 	rootCmd.PersistentFlags().String("walletuser", "", "The username for Wallet RPC")
@@ -174,6 +175,7 @@ func always(cmd *cobra.Command, args []string) {
 	// Setup global command line flag overrides
 	// This gets run before any command executes. It will init global flags to the config
 	_ = viper.BindPFlag(config.LoggingLevel, cmd.Flags().Lookup("log"))
+	_ = viper.BindPFlag(config.Network, cmd.Flags().Lookup("network"))
 	_ = viper.BindPFlag(config.Server, cmd.Flags().Lookup("server"))
 	_ = viper.BindPFlag(config.Wallet, cmd.Flags().Lookup("wallet"))
 	_ = viper.BindPFlag(config.WalletUser, cmd.Flags().Lookup("walletuser"))

--- a/config/locations.go
+++ b/config/locations.go
@@ -12,6 +12,7 @@ const (
 	CustomSQLDBMode = "db.mode"
 	SQLDBWalMode    = "db.wal"
 
+	Network              = "app.Network"
 	Server               = "app.Server"
 	Wallet               = "app.Wallet"
 	WalletUser           = "app.WalletUser"

--- a/node/node.go
+++ b/node/node.go
@@ -87,6 +87,9 @@ type Pegnetd struct {
 }
 
 func NewPegnetd(ctx context.Context, conf *viper.Viper) (*Pegnetd, error) {
+	// init chainIds
+	InitChainsFromConfig(conf)
+
 	// TODO : Update emyrk's factom library
 	n := new(Pegnetd)
 	n.FactomClient = FactomClientFromConfig(conf)
@@ -146,4 +149,17 @@ func FactomClientFromConfig(conf *viper.Viper) *factom.Client {
 	}
 
 	return cl
+}
+
+func InitChainsFromConfig(conf *viper.Viper) {
+	network := conf.GetString(config.Network)
+	if network == "MainNet" {
+		OPRChain = factom.NewBytes32("a642a8674f46696cc47fdb6b65f9c87b2a19c5ea8123b3d2f0c13b6f33a9d5ef")
+		SPRChain = factom.NewBytes32("d5e395125335a21cef0ceca528168e87fe929fdac1f156870c1b1be6502448b4")
+		TransactionChain = factom.NewBytes32("cffce0f409ebba4ed236d49d89c70e4bd1f1367d86402a3363366683265a242d")
+	} else if network == "TestNet" {
+		OPRChain = factom.NewBytes32("f640503c1b7a6dfd58fa955d83cf0e974c22db4b5db1818f813d0f97a16809b2")
+		SPRChain = factom.NewBytes32("8efac3ae60d7506d31f0d9350e9cfbc00c90d28c817698efec6c5a7f6daf40e1")
+		TransactionChain = factom.NewBytes32("55f41a66de87fc09ce4cdede4bc32eaee1ce8db203192564078c9875662d6189")
+	}
 }

--- a/pegnetd-conf.toml
+++ b/pegnetd-conf.toml
@@ -1,5 +1,8 @@
 # Pegnetd config file
 [app]
+  # MainNet/TestNet
+  network = "MainNet"
+
   loglevel = "info"
   apilisten = "8070"
   # Hardcoding the mainnet path, but allowing for future net support
@@ -10,6 +13,5 @@
   wallet = "http://localhost:8089/v2"
   walletUser = ""
   walletPass = ""
-
 [dblocksync]
   retry = "5s"


### PR DESCRIPTION
Initialize the chainIds based on network (`MainNet` or `TestNet`)

- TestNetwork Transaction chain: 
https://testnet.factoid.org/data?type=chain&key=55f41a66de87fc09ce4cdede4bc32eaee1ce8db203192564078c9875662d6189

- TestNetwork OraclePriceRecordChain: 
https://testnet.factoid.org/data?type=chain&key=f640503c1b7a6dfd58fa955d83cf0e974c22db4b5db1818f813d0f97a16809b2

- TestNetwork StakingPriceRecordChain:
https://testnet.factoid.org/data?type=chain&key=8efac3ae60d7506d31f0d9350e9cfbc00c90d28c817698efec6c5a7f6daf40e1