### PR TITLE
Version 2.0.4: Mint tokens, Nullify tokens with activation heights

### DIFF
--- a/node/burns.go
+++ b/node/burns.go
@@ -13,6 +13,8 @@ var (
 
 	GlobalOldBurnAddress = "FA1y5ZGuHSLmf2TqNf6hVMkPiNGyQpQDTFJvDLRkKQaoPo4bmbgu"
 
+	GlobalMintAddress = "FA3j16WPCiqsAFHVZcEoL85Khh5RhPCNe6PWHBKgUxrx8MAnbNoy"
+
 	// BurnRCD is the rcd representation of the burn address
 	BurnRCD = [32]byte{}
 )

--- a/node/mint.go
+++ b/node/mint.go
@@ -1,43 +1,45 @@
 package node
 
+import "github.com/pegnet/pegnetd/fat/fat2"
+
 // Special structure for the mint amount
 type MintSupply struct {
-	Token  string  // token
-	Amount float64 // amount of token to mint
+	Ticker fat2.PTicker // token
+	Amount uint64       // amount of token to mint
 }
 
 var (
-	MintTotalSupply = []MintSupply{
-		{"PEG", 334509613},
-		{"pUSD", 3184409},
-		{"pKRW", 118},
-		{"pXAU", 1},
-		{"pXAG", 599},
-		{"pXBT", 2},
-		{"pETH", 5476},
-		{"pLTC", 2004},
-		{"pRVN", 13124813},
-		{"pXBC", 243},
-		{"pBNB", 3461},
-		{"pXLM", 45892},
-		{"pADA", 1414096},
-		{"pXMR", 682},
-		{"pDASH", 6001},
-		{"pZEC", 2696},
-		{"pEOS", 2059},
-		{"pLINK", 9110},
-		{"pATOM", 101},
-		{"pNEO", 2},
-		{"pCRO", 164},
-		{"pETC", 5},
-		{"pVET", 22400000},
-		{"pHT", 5},
-		{"pDCR", 1049},
-		{"pAUD", 9},
-		{"pNOK", 59},
-		{"pXTZ", 11117},
-		{"pDOGE", 9870},
-		{"pALGO", 457602},
-		{"pDGB", 51175},
+	MintTotalSupplyMap = []MintSupply{
+		{fat2.PTickerPEG, 334509613},
+		{fat2.PTickerUSD, 3184409},
+		{fat2.PTickerKRW, 118},
+		{fat2.PTickerXAU, 1},
+		{fat2.PTickerXAG, 599},
+		{fat2.PTickerXBT, 2},
+		{fat2.PTickerETH, 5476},
+		{fat2.PTickerLTC, 2004},
+		{fat2.PTickerRVN, 13124813},
+		{fat2.PTickerXBC, 243},
+		{fat2.PTickerBNB, 3461},
+		{fat2.PTickerXLM, 45892},
+		{fat2.PTickerADA, 1414096},
+		{fat2.PTickerXMR, 682},
+		{fat2.PTickerDASH, 6001},
+		{fat2.PTickerZEC, 2696},
+		{fat2.PTickerEOS, 2059},
+		{fat2.PTickerLINK, 9110},
+		{fat2.PTickerATOM, 101},
+		{fat2.PTickerNEO, 2},
+		{fat2.PTickerCRO, 164},
+		{fat2.PTickerETC, 5},
+		{fat2.PTickerVET, 22400000},
+		{fat2.PTickerHT, 5},
+		{fat2.PTickerDCR, 1049},
+		{fat2.PTickerAUD, 9},
+		{fat2.PTickerNOK, 59},
+		{fat2.PTickerXTZ, 11117},
+		{fat2.PTickerDOGE, 9870},
+		{fat2.PTickerALGO, 457602},
+		{fat2.PTickerDGB, 51175},
 	}
 )

--- a/node/mint.go
+++ b/node/mint.go
@@ -1,0 +1,43 @@
+package node
+
+// Special structure for the mint amount
+type MintSupply struct {
+	Token  string  // token
+	Amount float64 // amount of token to mint
+}
+
+var (
+	MintTotalSupply = []MintSupply{
+		{"PEG", 334509613},
+		{"pUSD", 3184409},
+		{"pKRW", 118},
+		{"pXAU", 1},
+		{"pXAG", 599},
+		{"pXBT", 2},
+		{"pETH", 5476},
+		{"pLTC", 2004},
+		{"pRVN", 13124813},
+		{"pXBC", 243},
+		{"pBNB", 3461},
+		{"pXLM", 45892},
+		{"pADA", 1414096},
+		{"pXMR", 682},
+		{"pDASH", 6001},
+		{"pZEC", 2696},
+		{"pEOS", 2059},
+		{"pLINK", 9110},
+		{"pATOM", 101},
+		{"pNEO", 2},
+		{"pCRO", 164},
+		{"pETC", 5},
+		{"pVET", 22400000},
+		{"pHT", 5},
+		{"pDCR", 1049},
+		{"pAUD", 9},
+		{"pNOK", 59},
+		{"pXTZ", 11117},
+		{"pDOGE", 9870},
+		{"pALGO", 457602},
+		{"pDGB", 51175},
+	}
+)

--- a/node/node.go
+++ b/node/node.go
@@ -97,6 +97,8 @@ func SetAllActivations(act uint32) {
 	OneWaySmallAssetsConversions = act
 	SprSignatureActivation = act
 	V202EnhanceActivation = act
+	V204EnhanceActivation = act
+	V204BurnMintTokenActivation = act
 }
 
 type Pegnetd struct {

--- a/node/node.go
+++ b/node/node.go
@@ -76,6 +76,10 @@ var (
 	// V204EnhanceActivation indicates the activation of PegNet 2.0.4.
 	// Estimated to be  Mar 15th 2021
 	V204EnhanceActivation uint32 = 999999
+
+	// V204EnhanceActivation indicates the activation of PegNet 2.0.4.
+	// Estimated to be  Mar 15th 2021
+	V204BurnMintTokenActivation uint32 = 999999
 )
 
 func SetAllActivations(act uint32) {

--- a/node/node.go
+++ b/node/node.go
@@ -74,12 +74,12 @@ var (
 	V202EnhanceActivation uint32 = 274036
 
 	// V204EnhanceActivation indicates the activation of PegNet 2.0.4.
-	// Estimated to be  Mar 15th 2021
-	V204EnhanceActivation uint32 = 999999
+	// Estimated to be  Mar 16th 2021
+	V204EnhanceActivation uint32 = 288878
 
 	// V204EnhanceActivation indicates the activation that burns remaining airdrop amount.
-	// Estimated to be  April 15th 2021
-	V204BurnMintTokenActivation uint32 = 999999
+	// Estimated to be  April 16th 2021
+	V204BurnMintTokenActivation uint32 = 294206
 )
 
 func SetAllActivations(act uint32) {

--- a/node/node.go
+++ b/node/node.go
@@ -79,7 +79,7 @@ var (
 
 	// V204EnhanceActivation indicates the activation that burns remaining airdrop amount.
 	// Estimated to be  April 16th 2021
-	V204BurnMintTokenActivation uint32 = 294206
+	V204BurnMintedTokenActivation uint32 = 294206
 )
 
 func SetAllActivations(act uint32) {
@@ -98,7 +98,7 @@ func SetAllActivations(act uint32) {
 	SprSignatureActivation = act
 	V202EnhanceActivation = act
 	V204EnhanceActivation = act
-	V204BurnMintTokenActivation = act
+	V204BurnMintedTokenActivation = act
 }
 
 type Pegnetd struct {

--- a/node/node.go
+++ b/node/node.go
@@ -72,6 +72,10 @@ var (
 	// V202EnhanceActivation indicates the activation of PegNet 2.0.2.
 	// Estimated to be  Dec 3th 2020
 	V202EnhanceActivation uint32 = 274036
+
+	// V204EnhanceActivation indicates the activation of PegNet 2.0.4.
+	// Estimated to be  Mar 15th 2021
+	V204EnhanceActivation uint32 = 999999
 )
 
 func SetAllActivations(act uint32) {

--- a/node/node.go
+++ b/node/node.go
@@ -77,8 +77,8 @@ var (
 	// Estimated to be  Mar 15th 2021
 	V204EnhanceActivation uint32 = 999999
 
-	// V204EnhanceActivation indicates the activation of PegNet 2.0.4.
-	// Estimated to be  Mar 15th 2021
+	// V204EnhanceActivation indicates the activation that burns remaining airdrop amount.
+	// Estimated to be  April 15th 2021
 	V204BurnMintTokenActivation uint32 = 999999
 )
 

--- a/node/sync.go
+++ b/node/sync.go
@@ -175,6 +175,26 @@ OuterSyncLoop:
 func (d *Pegnetd) MintTokensForBalance(ctx context.Context, tx *sql.Tx, height uint32) error {
 	fLog := log.WithFields(log.Fields{"height": height})
 
+	FAGlobalMintAddress, err := factom.NewFAAddress(GlobalMintAddress)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Info("error getting mint address")
+		return err
+	}
+
+	for _, tokenSupply := range MintTotalSupplyMap {
+		_, err := d.Pegnet.AddToBalance(tx, &FAGlobalMintAddress, tokenSupply.Ticker, tokenSupply.Amount)
+		if err != nil {
+			fLog.WithFields(log.Fields{
+				"token":  tokenSupply.Ticker,
+				"amount": tokenSupply.Amount,
+				"error":  err,
+			}).Info("error minting token is failed")
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/node/sync.go
+++ b/node/sync.go
@@ -198,7 +198,7 @@ func (d *Pegnetd) MintTokensForBalance(ctx context.Context, tx *sql.Tx, height u
 	return nil
 }
 
-func (d *Pegnetd) NullifyMintTokens(ctx context.Context, tx *sql.Tx, height uint32) error {
+func (d *Pegnetd) NullifyMintedTokens(ctx context.Context, tx *sql.Tx, height uint32) error {
 	fLog := log.WithFields(log.Fields{"height": height})
 
 	FAGlobalMintAddress, err := factom.NewFAAddress(GlobalMintAddress)
@@ -345,8 +345,8 @@ func (d *Pegnetd) SyncBlock(ctx context.Context, tx *sql.Tx, height uint32) erro
 		}
 	}
 
-	if height == V204BurnMintTokenActivation {
-		if err := d.NullifyMintTokens(ctx, tx, d.Sync.Synced+1); err != nil {
+	if height == V204BurnMintedTokenActivation {
+		if err := d.NullifyMintedTokens(ctx, tx, d.Sync.Synced+1); err != nil {
 			return err
 		}
 	}

--- a/node/sync.go
+++ b/node/sync.go
@@ -172,6 +172,12 @@ OuterSyncLoop:
 	}
 }
 
+func (d *Pegnetd) MintTokensForBalance(ctx context.Context, tx *sql.Tx, height uint32) error {
+	fLog := log.WithFields(log.Fields{"height": height})
+
+	return nil
+}
+
 func (d *Pegnetd) NullifyBurnAddress(ctx context.Context, tx *sql.Tx, height uint32) error {
 	fLog := log.WithFields(log.Fields{"height": height})
 
@@ -215,7 +221,7 @@ func (d *Pegnetd) NullifyBurnAddress(ctx context.Context, tx *sql.Tx, height uin
 		}).Info("zeroing burn | balances retrieval failed")
 	}
 
-	i := 0  // value to keep witin 0-9 range for mock tx
+	i := 0 // value to keep witin 0-9 range for mock tx
 	j := 0 // value for uniqueness
 	if height >= V202EnhanceActivation {
 		j = 50
@@ -276,6 +282,12 @@ func (d *Pegnetd) SyncBlock(ctx context.Context, tx *sql.Tx, height uint32) erro
 	fLog := log.WithFields(log.Fields{"height": height})
 	if isDone(ctx) { // Just an example about how to handle it being cancelled
 		return context.Canceled
+	}
+
+	if height == V204EnhanceActivation {
+		if err := d.MintTokensForBalance(ctx, tx, d.Sync.Synced+1); err != nil {
+			return err
+		}
 	}
 
 	dblock := new(factom.DBlock)

--- a/node/sync.go
+++ b/node/sync.go
@@ -184,7 +184,7 @@ func (d *Pegnetd) MintTokensForBalance(ctx context.Context, tx *sql.Tx, height u
 	}
 
 	for _, tokenSupply := range MintTotalSupplyMap {
-		_, err := d.Pegnet.AddToBalance(tx, &FAGlobalMintAddress, tokenSupply.Ticker, tokenSupply.Amount)
+		_, err := d.Pegnet.AddToBalance(tx, &FAGlobalMintAddress, tokenSupply.Ticker, tokenSupply.Amount*1e8)
 		if err != nil {
 			fLog.WithFields(log.Fields{
 				"token":  tokenSupply.Ticker,
@@ -276,7 +276,7 @@ func (d *Pegnetd) NullifyBurnAddress(ctx context.Context, tx *sql.Tx, height uin
 		}).Info("zeroing burn | balances retrieval failed")
 	}
 
-	i := 0  // value to keep witin 0-9 range for mock tx
+	i := 0 // value to keep witin 0-9 range for mock tx
 	j := 0 // value for uniqueness
 	if height >= V202EnhanceActivation {
 		j = 50

--- a/node/sync.go
+++ b/node/sync.go
@@ -276,7 +276,7 @@ func (d *Pegnetd) NullifyBurnAddress(ctx context.Context, tx *sql.Tx, height uin
 		}).Info("zeroing burn | balances retrieval failed")
 	}
 
-	i := 0 // value to keep witin 0-9 range for mock tx
+	i := 0  // value to keep witin 0-9 range for mock tx
 	j := 0 // value for uniqueness
 	if height >= V202EnhanceActivation {
 		j = 50


### PR DESCRIPTION
- Add V204EnhanceActivation that indicates the activation of PegNet 2.0.4
- Add V204BurnMintTokenActivation that indicates the activation that burns remaining airdrop amount.
- MintTokensForBalance function that mint tokens for 2.0.4
- NullifyMintTokens that burns remaining funds from GlobalMintAddress
- Add GlobalMintAddress for AirDrop distribution
- Add MintTotalSupplyMap for AirDrop distribution