### PR TITLE
PIP-18: Delegate Staking

### DIFF
--- a/config/activations.go
+++ b/config/activations.go
@@ -82,7 +82,7 @@ var (
 	//	1. Balances of PEG for each address is more complicated.  It is the balance of PEG for the address (assuming it has not be delegated)
 	//	2. We quit looking at the rich list, and just consider the top 100 submissions with the highest stake
 	//	3. We pay out with the ratio of the total PEG staked. (Removes old top 100 PEG addresses staking reward and give staking opportunity to all PEG holders)
-	PIP18DelegateStakingActivation uint32 = 999999
+	PIP18DelegateStakingActivation uint32 = 313042
 )
 
 func SetAllActivations(act uint32) {

--- a/config/activations.go
+++ b/config/activations.go
@@ -82,7 +82,7 @@ var (
 	//	1. Balances of PEG for each address is more complicated.  It is the balance of PEG for the address (assuming it has not be delegated)
 	//	2. We quit looking at the rich list, and just consider the top 100 submissions with the highest stake
 	//	3. We pay out with the ratio of the total PEG staked. (Removes old top 100 PEG addresses staking reward and give staking opportunity to all PEG holders)
-	PIP18DelegateStakingActivation uint32 = 313906
+	PIP18DelegateStakingActivation uint32 = 314482
 )
 
 func SetAllActivations(act uint32) {

--- a/config/activations.go
+++ b/config/activations.go
@@ -82,7 +82,7 @@ var (
 	//	1. Balances of PEG for each address is more complicated.  It is the balance of PEG for the address (assuming it has not be delegated)
 	//	2. We quit looking at the rich list, and just consider the top 100 submissions with the highest stake
 	//	3. We pay out with the ratio of the total PEG staked. (Removes old top 100 PEG addresses staking reward and give staking opportunity to all PEG holders)
-	PIP18DelegateStakingActivation uint32 = 313042
+	PIP18DelegateStakingActivation uint32 = 313906
 )
 
 func SetAllActivations(act uint32) {

--- a/config/activations.go
+++ b/config/activations.go
@@ -77,6 +77,12 @@ var (
 	//
 	// Activation of 2.0.5
 	PIP10AverageActivation uint32 = 295190
+
+	// PIP18DelegateStakingActivation implements delegate staking by using PEG addresses.
+	//	1. Balances of PEG for each address is more complicated.  It is the balance of PEG for the address (assuming it has not be delegated)
+	//	2. We quit looking at the rich list, and just consider the top 100 submissions with the highest stake
+	//	3. We pay out with the ratio of the total PEG staked. (Removes old top 100 PEG addresses staking reward and give staking opportunity to all PEG holders)
+	PIP18DelegateStakingActivation uint32 = 999999
 )
 
 func SetAllActivations(act uint32) {
@@ -97,4 +103,5 @@ func SetAllActivations(act uint32) {
 	V204EnhanceActivation = act
 	V204BurnMintedTokenActivation = act
 	PIP10AverageActivation = act
+	PIP18DelegateStakingActivation = act
 }

--- a/node/pegnet/addresses.go
+++ b/node/pegnet/addresses.go
@@ -462,21 +462,23 @@ func (p *Pegnet) IsIncludedTopPEGAddress(address []byte) bool {
 	return false
 }
 
-func (p *Pegnet) IsNonZeroPEGAddress(address []byte) bool {
-	stmt2 := `SELECT COUNT(*) FROM pn_addresses WHERE peg_balance > 0 AND address = ?;`
+func (p *Pegnet) GetPEGAddress(address []byte) (uint64, error) {
+	stmt2 := `SELECT peg_balance FROM pn_addresses WHERE address = ?;`
 	rows, err2 := p.DB.Query(stmt2, address)
 	if err2 != nil {
 		fmt.Println("DB query is failed")
-		return false
+		return 0, err2
 	}
 	defer rows.Close()
 
 	for rows.Next() {
-		var count int
-		rows.Scan(&count)
-		return count > 0
+		var pegBalance uint64
+		if err := rows.Scan(&pegBalance); err != nil {
+			return 0, err
+		}
+		return pegBalance, nil
 	}
-	return false
+	return 0, nil
 }
 
 // SelectRichList returns the balance of all addresses for a given ticker

--- a/node/pegnet/addresses.go
+++ b/node/pegnet/addresses.go
@@ -462,6 +462,23 @@ func (p *Pegnet) IsIncludedTopPEGAddress(address []byte) bool {
 	return false
 }
 
+func (p *Pegnet) IsNonZeroPEGAddress(address []byte) bool {
+	stmt2 := `SELECT COUNT(*) FROM pn_addresses WHERE peg_balance > 0 AND address = ?;`
+	rows, err2 := p.DB.Query(stmt2, address[:])
+	if err2 != nil {
+		fmt.Println("DB query is failed")
+		return false
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var count int
+		rows.Scan(&count)
+		return count > 0
+	}
+	return false
+}
+
 // SelectRichList returns the balance of all addresses for a given ticker
 func (p *Pegnet) SelectRichList(ticker fat2.PTicker, count int) ([]BalancePair, error) {
 	if ticker <= fat2.PTickerInvalid || fat2.PTickerMax <= ticker {

--- a/node/pegnet/addresses.go
+++ b/node/pegnet/addresses.go
@@ -464,7 +464,7 @@ func (p *Pegnet) IsIncludedTopPEGAddress(address []byte) bool {
 
 func (p *Pegnet) IsNonZeroPEGAddress(address []byte) bool {
 	stmt2 := `SELECT COUNT(*) FROM pn_addresses WHERE peg_balance > 0 AND address = ?;`
-	rows, err2 := p.DB.Query(stmt2, address[:])
+	rows, err2 := p.DB.Query(stmt2, address)
 	if err2 != nil {
 		fmt.Println("DB query is failed")
 		return false

--- a/node/pegnet/txhistory.go
+++ b/node/pegnet/txhistory.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/pegnet/pegnet/modules/graderDelegateStake"
 	"strings"
 	"time"
 
@@ -390,6 +391,45 @@ func (p *Pegnet) InsertCoinbase(tx *sql.Tx, winner *grader.GradingOPR, addr []by
 // InsertCoinbase inserts the payouts from staking into the history system.
 // There is one transaction per winning SPR, with the entry hash pointing to that specific spr
 func (p *Pegnet) InsertStaking100Coinbase(tx *sql.Tx, winner *graderStake.GradingSPR, addr []byte, timestamp time.Time) error {
+	stmt, err := tx.Prepare(`INSERT INTO "pn_history_txbatch"
+                (entry_hash, height, blockorder, timestamp, executed) VALUES
+                (?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+
+	lookup, err := tx.Prepare(insertLookupQuery)
+	if err != nil {
+		return err
+	}
+
+	_, err = stmt.Exec(winner.EntryHash, winner.SPR.GetHeight(), 0, timestamp.Unix(), winner.SPR.GetHeight())
+	if err != nil {
+		return err
+	}
+
+	coinbaseStatement, err := tx.Prepare(`INSERT INTO "pn_history_transaction"
+                (entry_hash, tx_index, action_type, from_address, from_asset, from_amount, to_asset, to_amount, outputs) VALUES
+                (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+
+	_, err = coinbaseStatement.Exec(winner.EntryHash, 0, Coinbase, addr, "", 0, "PEG", winner.Payout(), "")
+	if err != nil {
+		return err
+	}
+
+	if _, err = lookup.Exec(winner.EntryHash, 0, addr); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InsertCoinbase inserts the payouts from staking into the history system.
+// There is one transaction per winning SPR, with the entry hash pointing to that specific spr
+func (p *Pegnet) InsertStaking100CoinbaseDelegate(tx *sql.Tx, winner *graderDelegateStake.GradingDelegatedSPR, addr []byte, timestamp time.Time) error {
 	stmt, err := tx.Prepare(`INSERT INTO "pn_history_txbatch"
                 (entry_hash, height, blockorder, timestamp, executed) VALUES
                 (?, ?, ?, ?, ?)`)

--- a/node/spr.go
+++ b/node/spr.go
@@ -63,6 +63,16 @@ func (d *Pegnetd) GradeS(ctx context.Context, block *factom.EBlock) (graderStake
 	return nil, nil
 }
 
+func isElementExist(element string, list []string) bool {
+	isExist := false
+	for j := 0; j < len(list); j++ {
+		if list[j] == element {
+			isExist = true
+		}
+	}
+	return isExist
+}
+
 // Grade Staking Price Records
 func (d *Pegnetd) GradeDelegatedS(ctx context.Context, block *factom.EBlock) (graderDelegateStake.DelegatedGradedBlock, error) {
 	if block == nil {
@@ -85,6 +95,7 @@ func (d *Pegnetd) GradeDelegatedS(ctx context.Context, block *factom.EBlock) (gr
 		if err != nil {
 			return nil, err
 		}
+		var groupOfDelegatorsAddress []string
 		for _, entry := range block.Entries {
 			extids := make([][]byte, len(entry.ExtIDs))
 			for i := range entry.ExtIDs {
@@ -101,8 +112,13 @@ func (d *Pegnetd) GradeDelegatedS(ctx context.Context, block *factom.EBlock) (gr
 					continue
 				}
 				for i := 0; i < len(listOfDelegatorsAddress); i++ {
+					isDuplicatedAddress := isElementExist(listOfDelegatorsAddress[i], groupOfDelegatorsAddress)
+					if isDuplicatedAddress {
+						continue
+					}
 					individualBalance, _ := d.Pegnet.GetPEGAddress([]byte(listOfDelegatorsAddress[i]))
 					balanceOfPEG += individualBalance
+					groupOfDelegatorsAddress = append(groupOfDelegatorsAddress, listOfDelegatorsAddress[i])
 				}
 			}
 			err = g.AddSPRV4(entry.Hash[:], extids, entry.Content, balanceOfPEG)

--- a/node/spr.go
+++ b/node/spr.go
@@ -55,7 +55,7 @@ func (d *Pegnetd) GradeS(ctx context.Context, block *factom.EBlock) (graderStake
 					//logrus.WithError(err).WithFields(logrus.Fields{"hash": entry.Hash.String()}).Debug("failed to add spr")
 				}
 			}
-		} else {
+		} else if d.Pegnet.IsNonZeroPEGAddress(stakerRCD) {
 			err = g.AddSPR(entry.Hash[:], extids, entry.Content)
 			if err != nil {
 				// This is a noisy debug print

--- a/node/spr.go
+++ b/node/spr.go
@@ -3,8 +3,10 @@ package node
 import (
 	"context"
 	"fmt"
+	"github.com/pegnet/pegnet/modules/spr"
 
 	"github.com/Factom-Asset-Tokens/factom"
+	"github.com/pegnet/pegnet/modules/graderDelegateStake"
 	"github.com/pegnet/pegnet/modules/graderStake"
 	"github.com/pegnet/pegnetd/config"
 )
@@ -35,22 +37,18 @@ func (d *Pegnetd) GradeS(ctx context.Context, block *factom.EBlock) (graderStake
 		ver = 8
 	}
 
-	g, err := graderStake.NewGrader(ver, int32(block.Height))
-	gv2, err2 := graderStake.NewGraderV4(ver, int32(block.Height))
-	if err != nil && ver < 8 {
-		return nil, err
-	}
-	if err2 != nil && ver >= 8 {
-		return nil, err2
-	}
-	for _, entry := range block.Entries {
-		extids := make([][]byte, len(entry.ExtIDs))
-		for i := range entry.ExtIDs {
-			extids[i] = entry.ExtIDs[i]
+	if ver < 8 {
+		g, err := graderStake.NewGrader(ver, int32(block.Height))
+		if err != nil {
+			return nil, err
 		}
-		// allow only top 100 stake holders submit prices
-		stakerRCD := extids[1]
-		if block.Height < config.PIP18DelegateStakingActivation {
+		for _, entry := range block.Entries {
+			extids := make([][]byte, len(entry.ExtIDs))
+			for i := range entry.ExtIDs {
+				extids[i] = entry.ExtIDs[i]
+			}
+			// allow only top 100 stake holders submit prices
+			stakerRCD := extids[1]
 			if d.Pegnet.IsIncludedTopPEGAddress(stakerRCD) {
 				// ignore bad opr errors
 				err = g.AddSPR(entry.Hash[:], extids, entry.Content)
@@ -59,14 +57,61 @@ func (d *Pegnetd) GradeS(ctx context.Context, block *factom.EBlock) (graderStake
 					//logrus.WithError(err).WithFields(logrus.Fields{"hash": entry.Hash.String()}).Debug("failed to add spr")
 				}
 			}
-		} else if pegBalance, _ := d.Pegnet.GetPEGAddress(stakerRCD); pegBalance > 0 {
-			err = gv2.AddSPRV4(entry.Hash[:], extids, entry.Content, pegBalance)
+		}
+		return g.Grade(), nil
+	}
+	return nil, nil
+}
+
+// Grade Staking Price Records
+func (d *Pegnetd) GradeDelegatedS(ctx context.Context, block *factom.EBlock) (graderDelegateStake.DelegatedGradedBlock, error) {
+	if block == nil {
+		// TODO: Handle the case where there is no opr block.
+		// 		Must delay conversions if this- happens
+		return nil, nil
+	}
+
+	if *block.ChainID != config.SPRChain {
+		return nil, fmt.Errorf("trying to grade a non-spr chain")
+	}
+
+	ver := uint8(8)
+	if block.Height >= config.PIP18DelegateStakingActivation {
+		ver = 8
+	}
+
+	if ver == 8 {
+		g, err := graderDelegateStake.NewDelegatedGrader(ver, int32(block.Height))
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range block.Entries {
+			extids := make([][]byte, len(entry.ExtIDs))
+			for i := range entry.ExtIDs {
+				extids[i] = entry.ExtIDs[i]
+			}
+			o2, errP := spr.ParseS1Content(entry.Content)
+			var balanceOfPEG uint64 = 0
+			if errP == nil {
+				balanceOfPEG, _ = d.Pegnet.GetPEGAddress([]byte(o2.Address))
+			}
+			if errP == nil && len(extids) == 5 && len(extids[0]) == 1 && extids[0][0] == 8 {
+				listOfDelegatorsAddress, err := g.GetDelegatorsAddress(extids[3], extids[4], o2.Address)
+				if err != nil {
+					continue
+				}
+				for i := 0; i < len(listOfDelegatorsAddress); i++ {
+					individualBalance, _ := d.Pegnet.GetPEGAddress([]byte(listOfDelegatorsAddress[i]))
+					balanceOfPEG += individualBalance
+				}
+			}
+			err = g.AddSPRV4(entry.Hash[:], extids, entry.Content, balanceOfPEG)
 			if err != nil {
 				// This is a noisy debug print
 				//logrus.WithError(err).WithFields(logrus.Fields{"hash": entry.Hash.String()}).Debug("failed to add spr")
 			}
 		}
+		return g.Grade(), nil
 	}
-
-	return g.Grade(), nil
+	return nil, nil
 }


### PR DESCRIPTION
1. PIP-18 use balances of PEG for each address which is more complicated.  It is the balance of PEG for the address (assuming it has not be delegated) 
2. It quits looking at the rich list, and just consider the top 100 submissions with the highest stake
3. PIP-18 pays out with the ratio of the total PEG staked. (Removes old top 100 PEG addresses staking reward and give staking opportunity to all PEG holders)